### PR TITLE
Drop rpm-lockfile-prototype bundle-patch/rpms.in.yaml from renovate config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ get latest pullspec from `kubectl get component tempo-bundle-quay -o yaml`, then
 ```bash
 kubectl create namespace openshift-tempo-operator
 operator-sdk run bundle -n openshift-tempo-operator quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-bundle-quay@sha256:2015d62b1c7f57e4724354eda7ccb2d806aa5d47e5e24b1c2e9596d3b39301c7
-operator-sdk cleanup tempo-product
+operator-sdk cleanup -n openshift-tempo-operator tempo-product
 ```
 
 ### Extract file based catalog from OpenShift index

--- a/renovate.json
+++ b/renovate.json
@@ -15,8 +15,7 @@
   "dockerfile": {
     "postUpgradeTasks": {
       "commands": [
-        "rpm-lockfile-prototype rpms.in.yaml",
-        "rpm-lockfile-prototype bundle-patch/rpms.in.yaml --outfile bundle-patch/rpms.lock.yaml"
+        "rpm-lockfile-prototype rpms.in.yaml"
       ],
       "fileFilters": ["**/rpms.lock.yaml"]
     }


### PR DESCRIPTION
This command is currently not allowed in `postUpgradeTasks`. See https://issues.redhat.com/browse/KFLUXBUGS-1928 for context.