### PR TITLE
bump build number only

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -42,8 +42,8 @@ LABEL operators.operatorframework.io.test.mediatype.v1=scorecard+v1
 LABEL operators.operatorframework.io.test.config.v1=tests/scorecard/
 
 
-LABEL release="0.14.2-1" \
-      version="0.14.2-1" \
+LABEL release="0.14.1-2" \
+      version="0.14.1-2" \
       com.redhat.openshift.versions=v4.12 \
       name="rhosdt/tempo-operator-bundle" \
       distribution-scope="public" \

--- a/bundle-patch/patch_csv.yaml
+++ b/bundle-patch/patch_csv.yaml
@@ -15,10 +15,10 @@ metadata:
     features.operators.openshift.io/cnf: "false"
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
-    olm.skipRange: '>=0.6.0 <0.14.2-1'
-  name: tempo-operator.v0.14.2-1
+    olm.skipRange: '>=0.6.0 <0.14.1-2'
+  name: tempo-operator.v0.14.1-2
 spec:
-  version: 0.14.2-1
+  version: 0.14.1-2
   replaces: tempo-operator.v0.14.1-1
   description: |-
     Red Hat OpenShift distributed tracing platform based on Tempo. Tempo is an open-source, easy-to-use, and highly scalable distributed tracing backend. It provides observability for microservices architectures by allowing developers to track requests as they flow through distributed systems. Tempo is optimized to handle large volumes of trace data and is designed to be highly performant even under heavy loads.


### PR DESCRIPTION
Due to an oversight we build tempo-operator 0.14.2, but did not update the version information in the CSV from 0.14.1.

To reduce confusion of this rebuild, let's stick to the wrong version and only bump the build number.