### PR TITLE
Disable arm64 builds on pull requests to speed up PR pipeline

### DIFF
--- a/.tekton/tempo-gateway-pull-request.yaml
+++ b/.tekton/tempo-gateway-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-platforms
     value:
       - localhost
-      - linux/arm64
+  #     - linux/arm64
   #     - linux/ppc64le
   #     - linux/s390x
   pipelineRef:

--- a/.tekton/tempo-jaeger-query-pull-request.yaml
+++ b/.tekton/tempo-jaeger-query-pull-request.yaml
@@ -53,7 +53,7 @@ spec:
   - name: build-platforms
     value:
       - localhost
-      - linux/arm64
+  #     - linux/arm64
   #     - linux/ppc64le
   #     - linux/s390x
   pipelineRef:

--- a/.tekton/tempo-opa-pull-request.yaml
+++ b/.tekton/tempo-opa-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-platforms
     value:
       - localhost
-      - linux/arm64
+  #     - linux/arm64
   #     - linux/ppc64le
   #     - linux/s390x
   pipelineRef:

--- a/.tekton/tempo-operator-pull-request.yaml
+++ b/.tekton/tempo-operator-pull-request.yaml
@@ -46,7 +46,7 @@ spec:
   - name: build-platforms
     value:
       - localhost
-      - linux/arm64
+#       - linux/arm64
 #      - linux/ppc64le
 #      - linux/s390x
   pipelineRef:

--- a/.tekton/tempo-query-pull-request.yaml
+++ b/.tekton/tempo-query-pull-request.yaml
@@ -53,7 +53,7 @@ spec:
   - name: build-platforms
     value:
       - localhost
-      - linux/arm64
+  #     - linux/arm64
   #     - linux/ppc64le
   #     - linux/s390x
   pipelineRef:

--- a/.tekton/tempo-tempo-pull-request.yaml
+++ b/.tekton/tempo-tempo-pull-request.yaml
@@ -54,7 +54,7 @@ spec:
   - name: build-platforms
     value:
       - localhost
-      - linux/arm64
+  #     - linux/arm64
   #     - linux/ppc64le
   #     - linux/s390x
   pipelineRef:


### PR DESCRIPTION
Disable arm64 builds on pull requests to speed up PR pipeline