### PR TITLE
Update integration test pipelines

### DIFF
--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-14.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-14.yaml
@@ -32,6 +32,10 @@ spec:
       description: Version of the Tempo query
     - name: operand_tempo_version
       description: Version of the Tempo operand
+    - name: tempo_tests_branch
+      description: "The repository branch from which to run the tests"
+    - name: skip_tests
+      description: "Tests to be skipped seperated with a space delimiter"
   tasks:
     - name: eaas-provision-space
       taskRef:
@@ -426,13 +430,16 @@ spec:
               echo "TEMPO IMAGE DETAILS AND VERSION INFO"
               echo
 
+              export TEMPO_ICSP=https://raw.githubusercontent.com/os-observability/konflux-tempo/refs/heads/main/.tekton/integration-tests/resources/ImageContentSourcePolicy.yaml
+              curl -Lo /tmp/ImageContentSourcePolicy.yaml "$TEMPO_ICSP"
+
               tempo_images=$(oc get deployment tempo-operator-controller -n openshift-tempo-operator -o yaml | grep -o "registry.redhat.io/rhosdt/.*" | sort | uniq)
               [ $(echo "$tempo_images" | wc -l) -eq 6 ] || exit_error "Expected 6 images, found:\n$tempo_images"
 
               oc project default
 
               for image in $tempo_images; do
-                  oc image info "$image" --filter-by-os linux/amd64
+                  oc image info "$image" --icsp-file /tmp/ImageContentSourcePolicy.yaml --filter-by-os linux/amd64
                   echo
 
                   random_name=$(generate_random_name)
@@ -467,7 +474,17 @@ spec:
       description: Task to run tests from service repository
       runAfter:
         - operators-install
+      params:
+        - name: TEMPO_TESTS_BRANCH
+          value: $(params.tempo_tests_branch)
+        - name: SKIP_TESTS
+          value: $(params.skip_tests)
       taskSpec:
+        params:
+          - name: TEMPO_TESTS_BRANCH
+            type: string
+          - name: SKIP_TESTS
+            type: string
         volumes:
           - name: credentials
             emptyDir: {}
@@ -500,6 +517,8 @@ spec:
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
+              TEMPO_TESTS_BRANCH=$(params.TEMPO_TESTS_BRANCH)
+              SKIP_TESTS=$(params.SKIP_TESTS)
               
               echo "Intall dependencies"
               dnf -y install jq vim unzip git make
@@ -548,17 +567,34 @@ spec:
               echo "Run e2e tests"
               git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests
               cd /tmp/tempo-tests
-              git checkout rhosdt-3-4-downstream
+              git checkout $TEMPO_TESTS_BRANCH
               make build
 
               #Enable user workload monitoring.
               oc apply -f tests/e2e-openshift/monitoring/01-workload-monitoring.yaml
+            
+              # Remove test cases to be skipped from the test run
+              IFS=' ' read -ra SKIP_TEST_ARRAY <<< "$SKIP_TESTS"
+              SKIP_TESTS_TO_REMOVE=""
+              INVALID_TESTS=""
+              for test in "${SKIP_TEST_ARRAY[@]}"; do
+                if [[ "$test" == tests/* ]]; then
+                  SKIP_TESTS_TO_REMOVE+=" $test"
+                else
+                  INVALID_TESTS+=" $test"
+                fi
+              done
+
+              if [[ -n "$INVALID_TESTS" ]]; then
+                echo "These test cases are not valid to be skipped: $INVALID_TESTS"
+              fi
+
+              if [[ -n "$SKIP_TESTS_TO_REMOVE" ]]; then
+                rm -rf $SKIP_TESTS_TO_REMOVE
+              fi
 
               # Unset environment variable which conflicts with Chainsaw
               unset NAMESPACE
-
-              # Initialize a variable to keep track of errors
-              any_errors=false
 
               # Execute Tempo e2e tests
               chainsaw test \
@@ -567,13 +603,7 @@ spec:
               tests/e2e \
               tests/e2e-openshift \
               tests/e2e-openshift-serverless \
+              tests/e2e-openshift-ossm \
+              tests/operator-metrics \
               tests/e2e-long-running \
-              tests/operator-metrics || any_errors=true
-
-              # Check if any errors occurred
-              if $any_errors; then
-                echo "Tests failed, check the logs for more details."
-                exit 1
-              else
-                echo "All the tests passed."
-              fi
+              tests/e2e-openshift-object-stores

--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-17.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-17.yaml
@@ -32,6 +32,10 @@ spec:
       description: Version of the Tempo query
     - name: operand_tempo_version
       description: Version of the Tempo operand
+    - name: tempo_tests_branch
+      description: "The repository branch from which to run the tests"
+    - name: skip_tests
+      description: "Tests to be skipped seperated with a space delimiter"
   tasks:
     - name: eaas-provision-space
       taskRef:
@@ -426,13 +430,16 @@ spec:
               echo "TEMPO IMAGE DETAILS AND VERSION INFO"
               echo
 
+              export TEMPO_ICSP=https://raw.githubusercontent.com/os-observability/konflux-tempo/refs/heads/main/.tekton/integration-tests/resources/ImageContentSourcePolicy.yaml
+              curl -Lo /tmp/ImageContentSourcePolicy.yaml "$TEMPO_ICSP"
+
               tempo_images=$(oc get deployment tempo-operator-controller -n openshift-tempo-operator -o yaml | grep -o "registry.redhat.io/rhosdt/.*" | sort | uniq)
               [ $(echo "$tempo_images" | wc -l) -eq 6 ] || exit_error "Expected 6 images, found:\n$tempo_images"
 
               oc project default
 
               for image in $tempo_images; do
-                  oc image info "$image" --filter-by-os linux/amd64
+                  oc image info "$image" --icsp-file /tmp/ImageContentSourcePolicy.yaml --filter-by-os linux/amd64
                   echo
 
                   random_name=$(generate_random_name)
@@ -467,7 +474,17 @@ spec:
       description: Task to run tests from service repository
       runAfter:
         - operators-install
+      params:
+        - name: TEMPO_TESTS_BRANCH
+          value: $(params.tempo_tests_branch)
+        - name: SKIP_TESTS
+          value: $(params.skip_tests)
       taskSpec:
+        params:
+          - name: TEMPO_TESTS_BRANCH
+            type: string
+          - name: SKIP_TESTS
+            type: string
         volumes:
           - name: credentials
             emptyDir: {}
@@ -500,6 +517,8 @@ spec:
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
+              TEMPO_TESTS_BRANCH=$(params.TEMPO_TESTS_BRANCH)
+              SKIP_TESTS=$(params.SKIP_TESTS)
               
               echo "Intall dependencies"
               dnf -y install jq vim unzip git make
@@ -548,17 +567,34 @@ spec:
               echo "Run e2e tests"
               git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests
               cd /tmp/tempo-tests
-              git checkout rhosdt-3-4-downstream
+              git checkout $TEMPO_TESTS_BRANCH
               make build
 
               #Enable user workload monitoring.
               oc apply -f tests/e2e-openshift/monitoring/01-workload-monitoring.yaml
+            
+              # Remove test cases to be skipped from the test run
+              IFS=' ' read -ra SKIP_TEST_ARRAY <<< "$SKIP_TESTS"
+              SKIP_TESTS_TO_REMOVE=""
+              INVALID_TESTS=""
+              for test in "${SKIP_TEST_ARRAY[@]}"; do
+                if [[ "$test" == tests/* ]]; then
+                  SKIP_TESTS_TO_REMOVE+=" $test"
+                else
+                  INVALID_TESTS+=" $test"
+                fi
+              done
+
+              if [[ -n "$INVALID_TESTS" ]]; then
+                echo "These test cases are not valid to be skipped: $INVALID_TESTS"
+              fi
+
+              if [[ -n "$SKIP_TESTS_TO_REMOVE" ]]; then
+                rm -rf $SKIP_TESTS_TO_REMOVE
+              fi
 
               # Unset environment variable which conflicts with Chainsaw
               unset NAMESPACE
-
-              # Initialize a variable to keep track of errors
-              any_errors=false
 
               # Execute Tempo e2e tests
               chainsaw test \
@@ -567,13 +603,7 @@ spec:
               tests/e2e \
               tests/e2e-openshift \
               tests/e2e-openshift-serverless \
+              tests/e2e-openshift-ossm \
+              tests/operator-metrics \
               tests/e2e-long-running \
-              tests/operator-metrics || any_errors=true
-
-              # Check if any errors occurred
-              if $any_errors; then
-                echo "Tests failed, check the logs for more details."
-                exit 1
-              else
-                echo "All the tests passed."
-              fi
+              tests/e2e-openshift-object-stores

--- a/.tekton/integration-tests/resources/ImageContentSourcePolicy.yaml
+++ b/.tekton/integration-tests/resources/ImageContentSourcePolicy.yaml
@@ -1,0 +1,27 @@
+apiVersion: operator.openshift.io/v1alpha1
+kind: ImageContentSourcePolicy
+metadata:
+  name: tempo-icsp
+spec:
+  repositoryDigestMirrors:
+  - source: registry.redhat.io/rhosdt/tempo-rhel8-operator
+    mirrors:
+      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-operator
+  - source: registry.redhat.io/rhosdt/tempo-rhel8
+    mirrors:
+      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo
+  - source: registry.redhat.io/rhosdt/tempo-query-rhel8
+    mirrors:
+      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-query
+  - source: registry.redhat.io/rhosdt/tempo-jaeger-query-rhel8
+    mirrors:
+      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-jaeger-query
+  - source: registry.redhat.io/rhosdt/tempo-gateway-rhel8
+    mirrors:
+      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-gateway
+  - source: registry.redhat.io/rhosdt/tempo-gateway-opa-rhel8
+    mirrors:
+      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-opa
+  - source: registry.redhat.io/rhosdt/tempo-operator-bundle
+    mirrors:
+      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-bundle


### PR DESCRIPTION
The PR updates the integration tests pipelines and adds vars to skip tests and specify the branch from which to run the e2e tests. 