### PR TITLE
Run the main app integration tests only on push events

### DIFF
--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-14.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-14.yaml
@@ -37,7 +37,26 @@ spec:
     - name: skip_tests
       description: "Tests to be skipped seperated with a space delimiter"
   tasks:
+    - name: parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
     - name: eaas-provision-space
+      runAfter:
+        - parse-metadata
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH" ]
       taskRef:
         resolver: git
         params:

--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-17.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-17.yaml
@@ -37,7 +37,26 @@ spec:
     - name: skip_tests
       description: "Tests to be skipped seperated with a space delimiter"
   tasks:
+    - name: parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
     - name: eaas-provision-space
+      runAfter:
+        - parse-metadata
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH" ]
       taskRef:
         resolver: git
         params:


### PR DESCRIPTION
Run only on push events to save on cost and resources. 