### PR TITLE
Use quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest for integration tests

### DIFF
--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-fbc-ocp-ci-job-trigger-pipeline.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-fbc-ocp-ci-job-trigger-pipeline.yaml
@@ -95,11 +95,8 @@ spec:
                 value: "$(params.OCP_CI_JOB_NAME)"
               - name: MULTISTAGE_PARAM_OVERRIDE_KEY
                 value: "$(params.MULTISTAGE_PARAM_OVERRIDE_KEY)"
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
-              echo "Install dependencies"
-              dnf -y install jq
-
               # Read the token from the secret file
               GANGWAY_API_TOKEN=$(cat /secrets/gangway-api-token/gangway_api_token)
 
@@ -153,7 +150,7 @@ spec:
                     break
                   else
                     echo "Job URL not yet available, waiting 5 seconds..."
-                    sleep 5
+                    sleep 15
                     ATTEMPT=$((ATTEMPT + 1))
                   fi
                 done

--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-14.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-14.yaml
@@ -205,19 +205,10 @@ spec:
             volumeMounts:
               - name: credentials
                 mountPath: /credentials
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
-              
-              echo "Install operator-sdk and dependencies"
-              dnf -y install jq python3-pip
-              export OPERATOR_SDK_VERSION=1.36.1
-              export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
-              export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}
-              curl -Lo /usr/local/bin/operator-sdk ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_${ARCH}
-              chmod +x /usr/local/bin/operator-sdk
-              operator-sdk version
 
               echo "Create namespace to install Tempo Operator"
               oc create namespace $(params.namespace)
@@ -288,7 +279,7 @@ spec:
             volumeMounts:
               - name: credentials
                 mountPath: /credentials
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
@@ -407,7 +398,7 @@ spec:
             volumeMounts:
               - name: credentials
                 mountPath: /credentials
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               #!/bin/bash
               set -eu
@@ -462,13 +453,6 @@ spec:
 
               echo "Kubeconfig file"
               cat $KUBECONFIG
-
-              echo "Install kubectl and oc"
-              cd /tmp/ \
-              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
-              && tar -xvzf oc.tar.gz \
-              && chmod +x kubectl oc \
-              && mv oc kubectl /usr/local/bin/
 
               echo
               echo
@@ -552,38 +536,10 @@ spec:
             env:
               - name: KUBECONFIG
                 value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
-
-              echo "Intall dependencies"
-              dnf -y install jq vim unzip git make
-
-              echo "Install GO"
-              curl -Lo /go.tar.gz https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
-              tar -C /usr/local -xzf /go.tar.gz
-              export PATH=$PATH:/usr/local/go/bin
-              # Set the Go path and Go cache environment variables
-              export GOPATH=/tmp/go
-              export GOBIN=/tmp/go/bin
-              export GOCACHE=/tmp/.cache/go-build
-              export PATH=$PATH:/tmp/go/bin
-
-              # Create the /tmp/go/bin and build cache directories, and grant read and write permissions to all users
-              mkdir -p /tmp/go/bin $GOCACHE \
-                && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
-              go version
-
-              echo "Install Chainsaw"
-              go install github.com/kyverno/chainsaw@v0.2.6
-
-              echo "Install kubectl and oc"
-              cd /tmp/ \
-              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
-              && tar -xvzf oc.tar.gz \
-              && chmod +x kubectl oc \
-              && mv oc kubectl /usr/local/bin/
 
               echo "Clone distributed-tracing-qe repository"
               git clone https://github.com/openshift/distributed-tracing-qe.git /tmp/distributed-tracing-tests
@@ -644,56 +600,12 @@ spec:
             env:
               - name: KUBECONFIG
                 value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
               TEMPO_TESTS_BRANCH=$(params.TEMPO_TESTS_BRANCH)
               SKIP_TESTS=$(params.SKIP_TESTS)
-              
-              echo "Intall dependencies"
-              dnf -y install jq vim unzip git make
-
-              echo "Install GO"
-              curl -Lo /go.tar.gz https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
-              tar -C /usr/local -xzf /go.tar.gz
-              export PATH=$PATH:/usr/local/go/bin
-              # Set the Go path and Go cache environment variables
-              export GOPATH=/tmp/go
-              export GOBIN=/tmp/go/bin
-              export GOCACHE=/tmp/.cache/go-build
-              export PATH=$PATH:/tmp/go/bin
-
-              # Create the /tmp/go/bin and build cache directories, and grant read and write permissions to all users
-              mkdir -p /tmp/go/bin $GOCACHE \
-                && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
-              go version
-
-              echo "Install Chainsaw"
-              go install github.com/kyverno/chainsaw@v0.2.6
-
-              echo "Install kubectl and oc"
-              cd /tmp/ \
-              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
-              && tar -xvzf oc.tar.gz \
-              && chmod +x kubectl oc \
-              && mv oc kubectl /usr/local/bin/
-
-              echo "Install AWS CLI"
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-              && unzip awscliv2.zip \
-              && ./aws/install
-
-              echo "Install Azure CLI"
-              rpm --import https://packages.microsoft.com/keys/microsoft.asc \
-              && dnf install -y https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm \
-              && dnf install -y azure-cli
-
-              echo "Install Google Cloud CLI"
-              curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz \
-              && tar -xf google-cloud-cli-linux-x86_64.tar.gz \
-              && ./google-cloud-sdk/install.sh -q
-              export PATH="/tmp/google-cloud-sdk/bin:${PATH}"
 
               echo "Run e2e tests"
               git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests

--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-17.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-17.yaml
@@ -205,19 +205,10 @@ spec:
             volumeMounts:
               - name: credentials
                 mountPath: /credentials
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
-              
-              echo "Install operator-sdk and dependencies"
-              dnf -y install jq python3-pip
-              export OPERATOR_SDK_VERSION=1.36.1
-              export ARCH=$(case $(uname -m) in x86_64) echo -n amd64 ;; aarch64) echo -n arm64 ;; *) echo -n $(uname -m) ;; esac)
-              export OPERATOR_SDK_DL_URL=https://github.com/operator-framework/operator-sdk/releases/download/v${OPERATOR_SDK_VERSION}
-              curl -Lo /usr/local/bin/operator-sdk ${OPERATOR_SDK_DL_URL}/operator-sdk_linux_${ARCH}
-              chmod +x /usr/local/bin/operator-sdk
-              operator-sdk version
 
               echo "Create namespace to install Tempo Operator"
               oc create namespace $(params.namespace)
@@ -288,7 +279,7 @@ spec:
             volumeMounts:
               - name: credentials
                 mountPath: /credentials
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
@@ -407,7 +398,7 @@ spec:
             volumeMounts:
               - name: credentials
                 mountPath: /credentials
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               #!/bin/bash
               set -eu
@@ -462,13 +453,6 @@ spec:
 
               echo "Kubeconfig file"
               cat $KUBECONFIG
-
-              echo "Install kubectl and oc"
-              cd /tmp/ \
-              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
-              && tar -xvzf oc.tar.gz \
-              && chmod +x kubectl oc \
-              && mv oc kubectl /usr/local/bin/
 
               echo
               echo
@@ -552,38 +536,10 @@ spec:
             env:
               - name: KUBECONFIG
                 value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
-
-              echo "Intall dependencies"
-              dnf -y install jq vim unzip git make
-
-              echo "Install GO"
-              curl -Lo /go.tar.gz https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
-              tar -C /usr/local -xzf /go.tar.gz
-              export PATH=$PATH:/usr/local/go/bin
-              # Set the Go path and Go cache environment variables
-              export GOPATH=/tmp/go
-              export GOBIN=/tmp/go/bin
-              export GOCACHE=/tmp/.cache/go-build
-              export PATH=$PATH:/tmp/go/bin
-
-              # Create the /tmp/go/bin and build cache directories, and grant read and write permissions to all users
-              mkdir -p /tmp/go/bin $GOCACHE \
-                && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
-              go version
-
-              echo "Install Chainsaw"
-              go install github.com/kyverno/chainsaw@v0.2.6
-
-              echo "Install kubectl and oc"
-              cd /tmp/ \
-              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
-              && tar -xvzf oc.tar.gz \
-              && chmod +x kubectl oc \
-              && mv oc kubectl /usr/local/bin/
 
               echo "Clone distributed-tracing-qe repository"
               git clone https://github.com/openshift/distributed-tracing-qe.git /tmp/distributed-tracing-tests
@@ -644,56 +600,12 @@ spec:
             env:
               - name: KUBECONFIG
                 value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
               TEMPO_TESTS_BRANCH=$(params.TEMPO_TESTS_BRANCH)
               SKIP_TESTS=$(params.SKIP_TESTS)
-              
-              echo "Intall dependencies"
-              dnf -y install jq vim unzip git make
-
-              echo "Install GO"
-              curl -Lo /go.tar.gz https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
-              tar -C /usr/local -xzf /go.tar.gz
-              export PATH=$PATH:/usr/local/go/bin
-              # Set the Go path and Go cache environment variables
-              export GOPATH=/tmp/go
-              export GOBIN=/tmp/go/bin
-              export GOCACHE=/tmp/.cache/go-build
-              export PATH=$PATH:/tmp/go/bin
-
-              # Create the /tmp/go/bin and build cache directories, and grant read and write permissions to all users
-              mkdir -p /tmp/go/bin $GOCACHE \
-                && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
-              go version
-
-              echo "Install Chainsaw"
-              go install github.com/kyverno/chainsaw@v0.2.6
-
-              echo "Install kubectl and oc"
-              cd /tmp/ \
-              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
-              && tar -xvzf oc.tar.gz \
-              && chmod +x kubectl oc \
-              && mv oc kubectl /usr/local/bin/
-
-              echo "Install AWS CLI"
-              curl "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o "awscliv2.zip" \
-              && unzip awscliv2.zip \
-              && ./aws/install
-
-              echo "Install Azure CLI"
-              rpm --import https://packages.microsoft.com/keys/microsoft.asc \
-              && dnf install -y https://packages.microsoft.com/config/rhel/8/packages-microsoft-prod.rpm \
-              && dnf install -y azure-cli
-
-              echo "Install Google Cloud CLI"
-              curl -LO https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz \
-              && tar -xf google-cloud-cli-linux-x86_64.tar.gz \
-              && ./google-cloud-sdk/install.sh -q
-              export PATH="/tmp/google-cloud-sdk/bin:${PATH}"
 
               echo "Run e2e tests"
               git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests

--- a/.tekton/integration-tests/pipelines/tempo-operator-upgrade-test-fbc-pipeline-4-14.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-upgrade-test-fbc-pipeline-4-14.yaml
@@ -228,39 +228,11 @@ spec:
                 value: "$(params.TEMPO_OPERATOR_VERSION)"
               - name: OPERATOR_CSV_VERSION
                 value: "$(params.OPERATOR_CSV_VERSION)"
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
               TEMPO_TESTS_BRANCH=$(params.TEMPO_TESTS_BRANCH)
-              
-              echo "Install dependencies"
-              dnf -y install jq vim unzip git make
-
-              echo "Install GO"
-              curl -Lo /go.tar.gz https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
-              tar -C /usr/local -xzf /go.tar.gz
-              export PATH=$PATH:/usr/local/go/bin
-              # Set the Go path and Go cache environment variables
-              export GOPATH=/tmp/go
-              export GOBIN=/tmp/go/bin
-              export GOCACHE=/tmp/.cache/go-build
-              export PATH=$PATH:/tmp/go/bin
-
-              # Create the /tmp/go/bin and build cache directories, and grant read and write permissions to all users
-              mkdir -p /tmp/go/bin $GOCACHE \
-                && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
-              go version
-
-              echo "Install Chainsaw"
-              go install github.com/kyverno/chainsaw@v0.2.12
-
-              echo "Install kubectl and oc"
-              cd /tmp/ \
-              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
-              && tar -xvzf oc.tar.gz \
-              && chmod +x kubectl oc \
-              && mv oc kubectl /usr/local/bin/
 
               echo "Run upgrade tests"
               git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests

--- a/.tekton/integration-tests/pipelines/tempo-operator-upgrade-test-fbc-pipeline-4-17.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-upgrade-test-fbc-pipeline-4-17.yaml
@@ -228,39 +228,11 @@ spec:
                 value: "$(params.TEMPO_OPERATOR_VERSION)"
               - name: OPERATOR_CSV_VERSION
                 value: "$(params.OPERATOR_CSV_VERSION)"
-            image: registry.redhat.io/openshift4/ose-cli:latest
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
             script: |
               echo "Kubeconfig file"
               cat $KUBECONFIG
               TEMPO_TESTS_BRANCH=$(params.TEMPO_TESTS_BRANCH)
-              
-              echo "Install dependencies"
-              dnf -y install jq vim unzip git make
-
-              echo "Install GO"
-              curl -Lo /go.tar.gz https://go.dev/dl/go1.22.10.linux-amd64.tar.gz
-              tar -C /usr/local -xzf /go.tar.gz
-              export PATH=$PATH:/usr/local/go/bin
-              # Set the Go path and Go cache environment variables
-              export GOPATH=/tmp/go
-              export GOBIN=/tmp/go/bin
-              export GOCACHE=/tmp/.cache/go-build
-              export PATH=$PATH:/tmp/go/bin
-
-              # Create the /tmp/go/bin and build cache directories, and grant read and write permissions to all users
-              mkdir -p /tmp/go/bin $GOCACHE \
-                && chmod -R 777 /tmp/go/bin $GOPATH $GOCACHE
-              go version
-
-              echo "Install Chainsaw"
-              go install github.com/kyverno/chainsaw@v0.2.12
-
-              echo "Install kubectl and oc"
-              cd /tmp/ \
-              && curl -L -o oc.tar.gz https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/latest/openshift-client-linux-amd64-rhel8.tar.gz \
-              && tar -xvzf oc.tar.gz \
-              && chmod +x kubectl oc \
-              && mv oc kubectl /usr/local/bin/
 
               echo "Run upgrade tests"
               git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests


### PR DESCRIPTION
The image has pre-installed tools and binaries which will save the job execution time. 