### PR TITLE
update renovatebot config

### DIFF
--- a/bundle-patch/bundle.env
+++ b/bundle-patch/bundle.env
@@ -14,4 +14,7 @@ TEMPO_OPA_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo
 
 TEMPO_OPERATOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-operator@sha256:ed7e1a11d035d49af4922eadebab2351f6e1694c012e7a5de657b30dd2075636
 
+# https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy/5cdb2133bed8bd5717d5ae64
+# Copy the image listed in "Get this image" > "Manifest List Digest" and make sure it's multi-arch (verify with "skopeo inspect --raw docker://registry.redhat.io/...")
+# renovate: follow_tag=latest
 OSE_OAUTH_PROXY_PULLSPEC=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:234af927030921ab8f7333f61f967b4b4dee37a1b3cf85689e9e63240dd62800

--- a/renovate.json
+++ b/renovate.json
@@ -1,26 +1,21 @@
 {
-  "extends": [
-    "github>konflux-ci/mintmaker//config/renovate/renovate.json"
-  ],
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "ignoreDeps": [
     "registry.redhat.io/openshift4/ose-operator-registry",
     "registry.redhat.io/openshift4/ose-operator-registry-rhel9"
   ],
-  "packageRules": [
-    {
-      "matchFileNames": ["bundle-patch/bundle.env"],
-      "groupName": "bundle images"
-    }
-  ],
-  "dockerfile": {
-    "postUpgradeTasks": {
-      "commands": [
-        "rpm-lockfile-prototype rpms.in.yaml"
-      ],
-      "fileFilters": ["**/rpms.lock.yaml"]
-    }
-  },
   "git-submodules": {
     "enabled": false
-  }
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Update digest of container images in .env files",
+      "managerFilePatterns": ["/\\.env$/"],
+      "matchStrings": [
+        "# renovate: follow_tag=(?<currentValue>[a-z-]+?)\\s.+?=(?<packageName>[^@:]+?)@(?<currentDigest>.+?)\\s"
+      ],
+      "datasourceTemplate": "docker"
+    }
+  ]
 }


### PR DESCRIPTION
* enable auto updates for registry.redhat.io images https://issues.redhat.com/browse/TRACING-5529
* add schema
* do not extend from base config. MintMaker already extends from the base config implicitly, and by linking to the main branch directly we could include configs which are not deployed yet https://konflux.pages.redhat.com/docs/users/mintmaker/user.html#create-your-custom-configuration