### PR TITLE
Fix oauth-proxy image

### DIFF
--- a/bundle-patch/bundle.env
+++ b/bundle-patch/bundle.env
@@ -14,7 +14,9 @@ TEMPO_OPA_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo
 
 TEMPO_OPERATOR_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-operator@sha256:b473f9a715af3eaacd8589e9d5eaf4e59912bf5c471de4e4b13d06b83cc73ce4
 
+# Tag v4.14 is built from commit https://github.com/openshift/oauth-proxy/commit/a4a2f27 (or later), which includes the required --upstream-timeout CLI flag introduced in https://github.com/openshift/oauth-proxy/commit/9bc353301f60b9290da7b5508576c9933297fec8
+# Do not use the latest tag, as the latest tag might point to v4.12 which does not include this CLI flag.
 # https://catalog.redhat.com/software/containers/openshift4/ose-oauth-proxy/5cdb2133bed8bd5717d5ae64
 # Copy the image listed in "Get this image" > "Manifest List Digest" and make sure it's multi-arch (verify with "skopeo inspect --raw docker://registry.redhat.io/...")
-# renovate: follow_tag=latest
-OSE_OAUTH_PROXY_PULLSPEC=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:dc24aa382e02c4ac058d4b824a21f0e90a6259d6d817d0341b2a41809b5daa78
+# renovate: follow_tag=v4.14
+OSE_OAUTH_PROXY_PULLSPEC=registry.redhat.io/openshift4/ose-oauth-proxy@sha256:6bcfa981a7a75c242a16afa6dab36bf6e3b8a1442fa863875919ad551f48eceb


### PR DESCRIPTION
The previous image did not include the required --upstream-timeout CLI flag introduced in https://github.com/openshift/oauth-proxy/commit/9bc353301f60b9290da7b5508576c9933297fec8