### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tempo-tempo-main

### DIFF
--- a/Dockerfile.tempo
+++ b/Dockerfile.tempo
@@ -51,6 +51,7 @@ LABEL release="${VERSION}" \
       distribution-scope="public" \
       url="https://github.com/grafana/tempo-operator" \
       com.redhat.component="tempo-container" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8" \
       name="rhosdt/tempo-rhel8" \
       summary="Tempo server" \
       description="Container for Tempo application" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
