### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tempo-query-main

### DIFF
--- a/Dockerfile.tempoquery
+++ b/Dockerfile.tempoquery
@@ -57,4 +57,5 @@ LABEL release="${VERSION}" \
       io.k8s.description="This container exposes a Jaeger Query compatible API from Tempo." \
       io.openshift.expose-services="16686:http,16687:metrics" \
       io.openshift.tags="tracing" \
-      io.k8s.display-name="Tempo Query"
+      io.k8s.display-name="Tempo Query" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
