### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tempo-gateway-main

### DIFF
--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -51,4 +51,5 @@ LABEL release="${VERSION}" \
       description="Horizontally-scalable authn/authz-securing reverse proxy for Tempo" \
       io.k8s.description="Horizontally-scalable authn/authz-securing reverse proxy for Tempo." \
       io.openshift.tags="tracing" \
-      io.k8s.display-name="Tempo Gateway"
+      io.k8s.display-name="Tempo Gateway" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
