### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tempo-opa-main

### DIFF
--- a/Dockerfile.opa
+++ b/Dockerfile.opa
@@ -51,4 +51,5 @@ LABEL release="${VERSION}" \
       description="An OPA-compatible API for making OpenShift access review requests" \
       io.k8s.description="An OPA-compatible API for making OpenShift access review requests." \
       io.openshift.tags="tracing" \
-      io.k8s.display-name="Tempo OPA"
+      io.k8s.display-name="Tempo OPA" \
+      cpe="cpe:/a:redhat:openshift_distributed_tracing:3.6::el8"


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
