### PR TITLE
Increase memory for jaeger-query build-images

### DIFF
--- a/.tekton/tempo-jaeger-query-pull-request.yaml
+++ b/.tekton/tempo-jaeger-query-pull-request.yaml
@@ -30,6 +30,14 @@ spec:
       computeResources:
         limits:
           memory: 4Gi # default: 3Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          memory: 5Gi
+        limits:
+          memory: 8Gi
   - pipelineTaskName: sast-shell-check
     stepSpecs:
     - name: use-trusted-artifact

--- a/.tekton/tempo-jaeger-query-push.yaml
+++ b/.tekton/tempo-jaeger-query-push.yaml
@@ -30,6 +30,14 @@ spec:
       computeResources:
         limits:
           memory: 4Gi # default: 3Gi
+  - pipelineTaskName: build-images
+    stepSpecs:
+    - name: build
+      computeResources:
+        requests:
+          memory: 5Gi
+        limits:
+          memory: 8Gi
   - pipelineTaskName: sast-shell-check
     stepSpecs:
     - name: use-trusted-artifact


### PR DESCRIPTION
## Summary

- The jaeger-query `build-images` step intermittently OOM-kills during multi-arch builds, causing flaky CI on main
- Recent main branch history shows 2 out of 3 commits had jaeger-query build failures (same code, different results)
- Set memory requests=5Gi, limits=8Gi for the `build` step in both pull-request and push pipelines

## Evidence

```
Commit 7a048ee (main): build-images 1 pass, 3 fail
Commit 1015fc1 (main): build-images 2 pass, 2 fail
```

Both failures show `exit status 1` at the Go build step with no useful error — consistent with OOM kill.

## Test plan

- [ ] Verify jaeger-query builds reliably on this PR
- [ ] Monitor for OOM after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)