### PR TITLE
fix: update catalog.env bundle pullspec to v0.20.0-3

### DIFF
--- a/catalog/catalog-template.yaml
+++ b/catalog/catalog-template.yaml
@@ -74,6 +74,9 @@ entries:
   - name: tempo-operator.v0.20.0-2
     replaces: tempo-operator.v0.20.0-1
     skipRange: '>=0.6.0 <0.20.0-2'
+  - name: tempo-operator.v0.20.0-3
+    replaces: tempo-operator.v0.20.0-2
+    skipRange: '>=0.6.0 <0.20.0-3'
   name: stable
   package: tempo-product
   schema: olm.channel
@@ -123,6 +126,8 @@ entries:
   schema: olm.bundle
 - image: registry.redhat.io/rhosdt/tempo-operator-bundle@sha256:90d1a71febb6cac99b64fc4863bcb66b11aa18c30dad93b244aca3290c3574e0
   schema: olm.bundle
-- image: quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-bundle@sha256:44aab3cb00053aff888ce8bbadca241807c6d400e881db4208dbcd1c311335ad
+- image: registry.redhat.io/rhosdt/tempo-operator-bundle@sha256:44aab3cb00053aff888ce8bbadca241807c6d400e881db4208dbcd1c311335ad
+  schema: olm.bundle
+- image: quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-bundle@sha256:d180bac53d873bba131cedd40db06cd784d8dc4795d9bff85a6b33921cc1dd9c
   schema: olm.bundle
 schema: olm.template.basic

--- a/catalog/catalog.env
+++ b/catalog/catalog.env
@@ -1,4 +1,4 @@
 # The bundle pullspec is taken and replaces in the catalog-template.yaml
 # Therefore only a single pullspec from quay.io has to be defined here.
 # sed -i 's#quay.*#'"$TEMPO_BUNDLE_IMAGE_PULLSPEC"'#g' catalog/catalog-template.yaml
-TEMPO_BUNDLE_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-bundle@sha256:acb976846fb356a839b7011c79bdcf2d29949a94b28586b5bd1ec19c2e378a71
+TEMPO_BUNDLE_IMAGE_PULLSPEC=quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-bundle@sha256:d180bac53d873bba131cedd40db06cd784d8dc4795d9bff85a6b33921cc1dd9c

--- a/catalog/tempo-product-4.17/catalog.yaml
+++ b/catalog/tempo-product-4.17/catalog.yaml
@@ -74,6 +74,9 @@ entries:
 - name: tempo-operator.v0.20.0-2
   replaces: tempo-operator.v0.20.0-1
   skipRange: '>=0.6.0 <0.20.0-2'
+- name: tempo-operator.v0.20.0-3
+  replaces: tempo-operator.v0.20.0-2
+  skipRange: '>=0.6.0 <0.20.0-3'
 name: stable
 package: tempo-product
 schema: olm.channel
@@ -25447,8 +25450,6 @@ properties:
     provider:
       name: Red Hat
 relatedImages:
-- image: registry.redhat.io/rhosdt/tempo-operator-bundle@sha256:44aab3cb00053aff888ce8bbadca241807c6d400e881db4208dbcd1c311335ad
-  name: ""
 - image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:6bcfa981a7a75c242a16afa6dab36bf6e3b8a1442fa863875919ad551f48eceb
   name: ose-oauth-proxy
 - image: registry.redhat.io/rhosdt/tempo-gateway-opa-rhel9@sha256:d8c3d067cd701b07dbad39fc6ea829a08b4e6234cc1ce05331abe152388743ae
@@ -25457,11 +25458,1483 @@ relatedImages:
   name: gateway
 - image: registry.redhat.io/rhosdt/tempo-jaeger-query-rhel9@sha256:a2cec745ebb8b80ebbd86808c0c34a7c16604d0f5fbb14ae182db9e08dde3284
   name: jaeger-query
+- image: registry.redhat.io/rhosdt/tempo-operator-bundle@sha256:44aab3cb00053aff888ce8bbadca241807c6d400e881db4208dbcd1c311335ad
+  name: ""
 - image: registry.redhat.io/rhosdt/tempo-query-rhel9@sha256:1aafaeb556a435fb7dafb49546f681eea75373d9cf610edc2b6a8aee33956ed2
   name: tempo-query
 - image: registry.redhat.io/rhosdt/tempo-rhel9-operator@sha256:43f93473bf97cb8012d327f0d29d01e1a882a5a02309f2b667143bf8f0cd4cf1
   name: operator
 - image: registry.redhat.io/rhosdt/tempo-rhel9@sha256:5fb9605ec704409ce0a4e2664278c1c67852210a20ccf3e7ff36a8343cb44306
+  name: tempo
+schema: olm.bundle
+---
+image: registry.redhat.io/rhosdt/tempo-operator-bundle@sha256:d180bac53d873bba131cedd40db06cd784d8dc4795d9bff85a6b33921cc1dd9c
+name: tempo-operator.v0.20.0-3
+package: tempo-product
+properties:
+- type: olm.gvk
+  value:
+    group: tempo.grafana.com
+    kind: TempoMonolithic
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: tempo.grafana.com
+    kind: TempoStack
+    version: v1alpha1
+- type: olm.package
+  value:
+    packageName: tempo-product
+    version: 0.20.0-3
+- type: olm.csv.metadata
+  value:
+    annotations:
+      alm-examples: |-
+        [
+          {
+            "apiVersion": "tempo.grafana.com/v1alpha1",
+            "kind": "TempoMonolithic",
+            "metadata": {
+              "name": "sample"
+            },
+            "spec": {
+              "jaegerui": {
+                "enabled": true,
+                "resources": {
+                  "limits": {
+                    "cpu": "2",
+                    "memory": "2Gi"
+                  }
+                },
+                "route": {
+                  "enabled": true
+                }
+              },
+              "resources": {
+                "limits": {
+                  "cpu": "2",
+                  "memory": "2Gi"
+                }
+              },
+              "storage": {
+                "traces": {
+                  "backend": "memory"
+                }
+              }
+            }
+          },
+          {
+            "apiVersion": "tempo.grafana.com/v1alpha1",
+            "kind": "TempoStack",
+            "metadata": {
+              "name": "sample"
+            },
+            "spec": {
+              "resources": {
+                "total": {
+                  "limits": {
+                    "cpu": "2000m",
+                    "memory": "2Gi"
+                  }
+                }
+              },
+              "storage": {
+                "secret": {
+                  "name": "my-storage-secret",
+                  "type": "s3"
+                }
+              },
+              "storageSize": "1Gi",
+              "template": {
+                "queryFrontend": {
+                  "jaegerQuery": {
+                    "enabled": true,
+                    "ingress": {
+                      "type": "route"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        ]
+      capabilities: Deep Insights
+      categories: Logging & Tracing,Monitoring,Observability
+      console.openshift.io/operator-monitoring-default: "true"
+      containerImage: registry.redhat.io/rhosdt/tempo-rhel9-operator@sha256:90c692e25861726382dfe60393d3ec57e3bad6037927a9d07ee15efa66dbc07e
+      createdAt: 20 Apr 2026, 08:49
+      description: Create and manage deployments of Tempo, a high-scale distributed
+        tracing backend.
+      features.operators.openshift.io/cnf: "false"
+      features.operators.openshift.io/cni: "false"
+      features.operators.openshift.io/csi: "false"
+      features.operators.openshift.io/disconnected: "true"
+      features.operators.openshift.io/fips-compliant: "true"
+      features.operators.openshift.io/proxy-aware: "true"
+      features.operators.openshift.io/tls-profiles: "true"
+      features.operators.openshift.io/token-auth-aws: "true"
+      features.operators.openshift.io/token-auth-azure: "false"
+      features.operators.openshift.io/token-auth-gcp: "false"
+      olm.skipRange: '>=0.6.0 <0.20.0-3'
+      operatorframework.io/cluster-monitoring: "true"
+      operatorframework.io/suggested-namespace: openshift-tempo-operator
+      operators.openshift.io/infrastructure-features: '["disconnected"]'
+      operators.openshift.io/valid-subscription: '["OpenShift Container Platform",
+        "OpenShift Platform Plus"]'
+      operators.operatorframework.io/builder: operator-sdk-v1.36.0
+      operators.operatorframework.io/project_layout: go.kubebuilder.io/v4
+      repository: https://github.com/grafana/tempo-operator
+      support: Red Hat
+    apiServiceDefinitions: {}
+    crdDescriptions:
+      owned:
+      - description: TempoMonolithic manages a Tempo deployment in monolithic mode.
+        displayName: TempoMonolithic
+        kind: TempoMonolithic
+        name: tempomonolithics.tempo.grafana.com
+        resources:
+        - kind: ConfigMap
+          name: ""
+          version: v1
+        - kind: Ingress
+          name: ""
+          version: v1
+        - kind: Route
+          name: ""
+          version: v1
+        - kind: Secret
+          name: ""
+          version: v1
+        - kind: Service
+          name: ""
+          version: v1
+        - kind: ServiceAccount
+          name: ""
+          version: v1
+        - kind: StatefulSet
+          name: ""
+          version: v1
+        specDescriptors:
+        - description: |-
+            Enabled defines if OTLP over gRPC is enabled.
+            Default: enabled.
+          displayName: Enabled
+          path: ingestion.otlp.grpc.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Enabled defines if TLS is enabled.
+          displayName: Enabled
+          path: ingestion.otlp.grpc.tls.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: |-
+            Enabled defines if OTLP over HTTP is enabled.
+            Default: enabled.
+          displayName: Enabled
+          path: ingestion.otlp.http.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Enabled defines if TLS is enabled.
+          displayName: Enabled
+          path: ingestion.otlp.http.tls.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Defines if the authentication will be enabled for jaeger UI.
+          displayName: Enabled
+          path: jaegerui.authentication.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Enabled defines if the Jaeger UI component should be created.
+          displayName: Enabled
+          path: jaegerui.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Enabled defines if an Ingress object should be created for
+            Jaeger UI.
+          displayName: Enabled
+          path: jaegerui.ingress.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Enabled defines if a Route object should be created for Jaeger
+            UI.
+          displayName: Enabled
+          path: jaegerui.route.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Enabled defines if a Grafana data source should be created
+            for this Tempo deployment.
+          displayName: Enabled
+          path: observability.grafana.dataSource.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Enabled defines if PrometheusRule objects should be created
+            for this Tempo deployment.
+          displayName: Enabled
+          path: observability.metrics.prometheusRules.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Enabled defines if ServiceMonitor objects should be created
+            for this Tempo deployment.
+          displayName: Enabled
+          path: observability.metrics.serviceMonitors.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Storage defines the storage configuration.
+          displayName: Storage
+          path: storage
+        - description: |-
+            Backend defines the backend for storing traces.
+            Default: memory.
+          displayName: Storage Backend
+          path: storage.traces.backend
+        - description: Enabled defines if TLS is enabled.
+          displayName: Enabled
+          path: storage.traces.s3.tls.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Ingestion defines the trace ingestion configuration.
+          displayName: Ingestion
+          path: ingestion
+        - description: Resources defines the compute resource requirements of the
+            Jaeger UI container.
+          displayName: Resources
+          path: jaegerui.resources
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        - description: Resources defines the compute resource requirements of the
+            Tempo Query container.
+          displayName: Resources
+          path: jaegerui.tempoQueryResources
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        - description: |-
+            Size defines the size of the volume where traces are stored.
+            For in-memory storage, this defines the size of the tmpfs volume.
+            For persistent volume storage, this defines the size of the persistent volume.
+            For object storage, this defines the size of the persistent volume containing the Write-Ahead Log (WAL) of Tempo.
+            Default: 2Gi for memory, 10Gi for all other backends.
+          displayName: Size
+          path: storage.traces.size
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: JaegerUI defines the Jaeger UI configuration.
+          displayName: Jaeger UI
+          path: jaegerui
+        - description: Ingress defines the Ingress configuration for the Jaeger UI.
+          displayName: Ingress
+          path: jaegerui.ingress
+        - description: StorageClassName for the PVC used by the Tempo Pod. Defaults
+            to nil (uses the default storage class in the cluster).
+          displayName: Storage Class
+          path: storage.traces.storageClassName
+        - description: Route defines the OpenShift route configuration for the Jaeger
+            UI.
+          displayName: Route
+          path: jaegerui.route
+        - description: Observability defines the observability configuration of the
+            Tempo deployment.
+          displayName: Observability
+          path: observability
+        - description: Authentication defines the options for the oauth proxy used
+            to protect jaeger UI
+          displayName: Jaeger UI authentication configuration
+          path: jaegerui.authentication
+        - description: Resources defines the compute resource requirements of the
+            Tempo container.
+          displayName: Resources
+          path: resources
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        - description: Affinity defines the Affinity rules for scheduling pods.
+          displayName: Affinity
+          path: affinity
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: ExtraConfig defines any extra (overlay) configuration of components.
+          displayName: Extra Configuration
+          path: extraConfig
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: Tempo defines any extra Tempo configuration, which will be
+            merged with the operator's generated Tempo configuration
+          displayName: Tempo Extra Configurations
+          path: extraConfig.tempo
+        - description: OTLP defines the ingestion configuration for the OTLP protocol.
+          displayName: OTLP
+          path: ingestion.otlp
+        - description: GRPC defines the OTLP over gRPC configuration.
+          displayName: gRPC
+          path: ingestion.otlp.grpc
+        - description: |-
+            TLS defines the TLS configuration for OTLP/gRPC ingestion.
+
+
+            On OpenShift when operator config `servingCertsService`  and TLS is enabled  but no `certName` and `caName`
+            are provided it will use OpenShift serving certificate service.
+          displayName: TLS
+          path: ingestion.otlp.grpc.tls
+        - description: |-
+            CA is the name of a ConfigMap containing a CA certificate (service-ca.crt).
+            It needs to be in the same namespace as the Tempo custom resource.
+          displayName: CA ConfigMap
+          path: ingestion.otlp.grpc.tls.caName
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:ConfigMap
+        - description: |-
+            Cert is the name of a Secret containing a certificate (tls.crt) and private key (tls.key).
+            It needs to be in the same namespace as the Tempo custom resource.
+          displayName: Certificate Secret
+          path: ingestion.otlp.grpc.tls.certName
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: MinVersion defines the minimum acceptable TLS version.
+          displayName: Min TLS Version
+          path: ingestion.otlp.grpc.tls.minVersion
+        - description: HTTP defines the OTLP over HTTP configuration.
+          displayName: HTTP
+          path: ingestion.otlp.http
+        - description: |-
+            TLS defines the TLS configuration for OTLP/HTTP ingestion.
+
+
+            On OpenShift when operator config `servingCertsService`  and TLS is enabled  but no `certName` and `caName`
+            are provided it will use OpenShift serving certificate service.
+          displayName: TLS
+          path: ingestion.otlp.http.tls
+        - description: |-
+            CA is the name of a ConfigMap containing a CA certificate (service-ca.crt).
+            It needs to be in the same namespace as the Tempo custom resource.
+          displayName: CA ConfigMap
+          path: ingestion.otlp.http.tls.caName
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:ConfigMap
+        - description: |-
+            Cert is the name of a Secret containing a certificate (tls.crt) and private key (tls.key).
+            It needs to be in the same namespace as the Tempo custom resource.
+          displayName: Certificate Secret
+          path: ingestion.otlp.http.tls.certName
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: MinVersion defines the minimum acceptable TLS version.
+          displayName: Min TLS Version
+          path: ingestion.otlp.http.tls.minVersion
+        - description: |-
+            Resources defines the compute resource requirements of the OAuth Proxy container.
+            The OAuth Proxy performs authentication and authorization of incoming requests to Jaeger UI when multi-tenancy is disabled.
+          displayName: Resources
+          path: jaegerui.authentication.resources
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        - description: |-
+            SAR defines the SAR to be used in the oauth-proxy
+            default is "{"namespace": "<tempo_stack_namespace>", "resource": "pods", "verb": "get"}
+          displayName: SAR
+          path: jaegerui.authentication.sar
+        - description: |-
+            FindTracesConcurrentRequests defines how many concurrent request a single trace search can submit (defaults 2).
+            The search for traces in Jaeger submits limit+1 requests. First requests finds trace IDs and then it fetches
+            entire traces by ID. This property allows Jaeger to fetch traces in parallel.
+            Note that by default a single Tempo querier can process 20 concurrent search jobs.
+            Increasing this property might require scaling up querier instances, especially on error "job queue full"
+            See also Tempo's extraConfig:
+            querier.max_concurrent_queries (20 default)
+            query_frontend.max_outstanding_per_tenant: (2000 default). Increase if the query-frontend returns 429
+          displayName: FindTracesConcurrentRequests
+          path: jaegerui.findTracesConcurrentRequests
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: Annotations defines the annotations of the Ingress object.
+          displayName: Annotations
+          path: jaegerui.ingress.annotations
+        - description: Host defines the hostname of the Ingress object.
+          displayName: Hostname
+          path: jaegerui.ingress.host
+        - description: |-
+            IngressClassName defines the name of an IngressClass cluster resource.
+            Defines which ingress controller serves this ingress resource.
+          displayName: Ingress Class Name
+          path: jaegerui.ingress.ingressClassName
+        - description: Annotations defines the annotations of the Route object.
+          displayName: Annotations
+          path: jaegerui.route.annotations
+        - description: Host defines the hostname of the Route object.
+          displayName: Hostname
+          path: jaegerui.route.host
+        - description: Termination specifies the termination type.
+          displayName: TLS Termination
+          path: jaegerui.route.termination
+        - description: ServicesQueryDuration defines how long the services will be
+            available in the services list
+          displayName: ServicesQueryDuration
+          path: jaegerui.servicesQueryDuration
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: |-
+            ManagementState defines whether this instance is managed by the operator or self-managed.
+            Default: Managed.
+          displayName: Management State
+          path: management
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: Multitenancy defines the multi-tenancy configuration.
+          displayName: Multi-Tenancy
+          path: multitenancy
+        - description: Authentication defines the tempo-gateway component authentication
+            configuration spec per tenant.
+          displayName: Authentication
+          path: multitenancy.authentication
+        - description: OIDC defines the spec for the OIDC tenant's authentication.
+          displayName: OIDC Configuration
+          path: multitenancy.authentication[0].oidc
+        - description: IssuerURL defines the URL for issuer.
+          displayName: Issuer URL
+          path: multitenancy.authentication[0].oidc.issuerURL
+        - description: RedirectURL defines the URL for redirect.
+          displayName: Redirect URL
+          path: multitenancy.authentication[0].oidc.redirectURL
+        - description: Secret defines the spec for the clientID, clientSecret and
+            issuerCAPath for tenant's authentication.
+          displayName: Tenant Secret
+          path: multitenancy.authentication[0].oidc.secret
+        - description: Name of a secret in the namespace configured for tenant secrets.
+          displayName: Tenant Secret Name
+          path: multitenancy.authentication[0].oidc.secret.name
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: |-
+            TenantID defines a universally unique identifier of the tenant.
+            Unlike the tenantName, which must be unique at a given time, the tenantId must be unique over the entire lifetime of the Tempo deployment.
+            Tempo uses this ID to prefix objects in the object storage.
+          displayName: Tenant ID
+          path: multitenancy.authentication[0].tenantId
+        - description: |-
+            TenantName defines a human readable, unique name of the tenant.
+            The value of this field must be specified in the X-Scope-OrgID header and in the resources field of a ClusterRole to identify the tenant.
+          displayName: Tenant Name
+          path: multitenancy.authentication[0].tenantName
+        - description: Authorization defines the tempo-gateway component authorization
+            configuration spec per tenant.
+          displayName: Authorization
+          path: multitenancy.authorization
+        - description: RoleBindings defines configuration to bind a set of roles to
+            a set of subjects.
+          displayName: Static Role Bindings
+          path: multitenancy.authorization.roleBindings
+        - description: Roles defines a set of permissions to interact with a tenant.
+          displayName: Static Roles
+          path: multitenancy.authorization.roles
+        - description: Enabled defines if multi-tenancy is enabled.
+          displayName: Enabled
+          path: multitenancy.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Mode defines the multitenancy mode.
+          displayName: Mode
+          path: multitenancy.mode
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:static
+          - urn:alm:descriptor:com.tectonic.ui:select:openshift
+        - description: |-
+            Resources defines the compute resource requirements of the gateway container.
+            The gateway performs authentication and authorization of incoming requests when multi-tenancy is enabled.
+          displayName: Resources
+          path: multitenancy.resources
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        - description: NodeSelector defines which labels are required by a node to
+            schedule the pod onto it.
+          displayName: Node Selector
+          path: nodeSelector
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: Grafana defines the Grafana configuration of the Tempo deployment.
+          displayName: Grafana
+          path: observability.grafana
+        - description: DataSource defines the Grafana data source configuration.
+          displayName: Grafana data source
+          path: observability.grafana.dataSource
+        - description: InstanceSelector defines the Grafana instance where the data
+            source should be created.
+          displayName: Instance Selector
+          path: observability.grafana.dataSource.instanceSelector
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:selector:grafana.integreatly.org:v1beta1:Grafana
+        - description: Metrics defines the metric configuration of the Tempo deployment.
+          displayName: Metrics
+          path: observability.metrics
+        - description: ServiceMonitors defines the PrometheusRule configuration.
+          displayName: Prometheus Rules
+          path: observability.metrics.prometheusRules
+        - description: ExtraLabels defines additional labels for the PrometheusRules
+            objects.
+          displayName: Extra Labels
+          path: observability.metrics.prometheusRules.extraLabels
+        - description: ServiceMonitors defines the ServiceMonitor configuration.
+          displayName: Service Monitors
+          path: observability.metrics.serviceMonitors
+        - description: ExtraLabels defines additional labels for the ServiceMonitor
+            objects.
+          displayName: Extra Labels
+          path: observability.metrics.serviceMonitors.extraLabels
+        - description: PodSecurityContext defines the security context that will be
+            applied to the Tempo Pod.
+          displayName: PodSecurityContext
+          path: podSecurityContext
+        - description: Query defines query configuration.
+          displayName: Query Configuration
+          path: query
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: |-
+            MCPServer defines the MCP (Model Context Protocol) server configuration.
+            The MCP server allows AI assistants to query tracing data.
+          displayName: MCP Server Settings
+          path: query.mcpServer
+        - description: Enabled defines if the MCP (Model Context Protocol) server
+            should be enabled.
+          displayName: Enable MCP Server
+          path: query.mcpServer.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: |-
+            RBAC defines query RBAC options.
+            This option can be used only with multi-tenancy.
+          displayName: Query RBAC Settings
+          path: query.rbac
+        - description: Enabled defines if the query RBAC should be enabled.
+          displayName: Query RBAC Enabled
+          path: query.rbac.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: ServiceAccount defines the Service Account to use for all Tempo
+            components.
+          displayName: Service Account
+          path: serviceAccount
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: Traces defines the storage configuration for traces.
+          displayName: Traces
+          path: storage.traces
+        - description: Azure defines the configuration for Azure Storage.
+          displayName: Azure Storage
+          path: storage.traces.azure
+        - description: |-
+            Secret is the name of a Secret containing credentials for accessing object storage.
+            It needs to be in the same namespace as the TempoMonolithic custom resource.
+          displayName: Storage Secret
+          path: storage.traces.azure.secret
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: GCP defines the configuration for Google Cloud Storage.
+          displayName: Google Cloud Storage
+          path: storage.traces.gcs
+        - description: |-
+            Secret is the name of a Secret containing credentials for accessing object storage.
+            It needs to be in the same namespace as the TempoMonolithic custom resource.
+          displayName: Storage Secret
+          path: storage.traces.gcs.secret
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: S3 defines the configuration for Amazon S3.
+          displayName: Amazon S3
+          path: storage.traces.s3
+        - description: |-
+            Secret is the name of a Secret containing credentials for accessing object storage.
+            It needs to be in the same namespace as the TempoMonolithic custom resource.
+          displayName: Storage Secret
+          path: storage.traces.s3.secret
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: TLS defines the TLS configuration for Amazon S3.
+          displayName: TLS
+          path: storage.traces.s3.tls
+        - description: |-
+            CA is the name of a ConfigMap containing a CA certificate (service-ca.crt).
+            It needs to be in the same namespace as the Tempo custom resource.
+          displayName: CA ConfigMap
+          path: storage.traces.s3.tls.caName
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:ConfigMap
+        - description: |-
+            Cert is the name of a Secret containing a certificate (tls.crt) and private key (tls.key).
+            It needs to be in the same namespace as the Tempo custom resource.
+          displayName: Certificate Secret
+          path: storage.traces.s3.tls.certName
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: MinVersion defines the minimum acceptable TLS version.
+          displayName: Min TLS Version
+          path: storage.traces.s3.tls.minVersion
+        - description: Tolerations defines the tolerations of a node to schedule the
+            pod onto it.
+          displayName: Tolerations
+          path: tolerations
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        statusDescriptors:
+        - description: Tempo is a map of the pod status of the Tempo pods.
+          displayName: Tempo
+          path: components.tempo
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:podStatuses
+        - description: Conditions of the Tempo deployment health.
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+      - description: TempoStack manages a Tempo deployment in microservices mode.
+        displayName: TempoStack
+        kind: TempoStack
+        name: tempostacks.tempo.grafana.com
+        resources:
+        - kind: ConfigMap
+          name: ""
+          version: v1
+        - kind: Deployment
+          name: ""
+          version: v1
+        - kind: Ingress
+          name: ""
+          version: v1
+        - kind: Route
+          name: ""
+          version: v1
+        - kind: Secret
+          name: ""
+          version: v1
+        - kind: Service
+          name: ""
+          version: v1
+        - kind: ServiceAccount
+          name: ""
+          version: v1
+        - kind: StatefulSet
+          name: ""
+          version: v1
+        specDescriptors:
+        - description: Enabled defines if TLS is enabled.
+          displayName: Enabled
+          path: storage.tls.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Enabled defines if TLS is enabled.
+          displayName: Enabled
+          path: template.distributor.tls.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Defines if the authentication will be enabled for jaeger UI.
+          displayName: Enabled
+          path: template.queryFrontend.jaegerQuery.authentication.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - displayName: Extra Configurations
+          path: extraConfig
+        - description: Tempo defines any extra Tempo configuration, which will be
+            merged with the operator's generated Tempo configuration
+          displayName: Tempo Extra Configurations
+          path: extraConfig.tempo
+        - description: HashRing defines the spec for the distributed hash ring configuration.
+          displayName: Hash Ring
+          path: hashRing
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: MemberList configuration spec
+          displayName: Memberlist Config
+          path: hashRing.memberlist
+        - description: EnableIPv6 enables IPv6 support for the memberlist based hash
+            ring.
+          displayName: Enable IPv6
+          path: hashRing.memberlist.enableIPv6
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: |-
+            InstanceAddrType defines the type of address to use to advertise to the ring.
+            Defaults to the first address from any private network interfaces of the current pod.
+            Alternatively the public pod IP can be used in case private networks (RFC 1918 and RFC 6598)
+            are not available.
+          displayName: Instance Address
+          path: hashRing.memberlist.instanceAddrType
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:default
+          - urn:alm:descriptor:com.tectonic.ui:select:podIP
+        - description: Images defines the image for each container.
+          displayName: Container Images
+          path: images
+        - description: LimitSpec is used to limit ingestion and querying rates.
+          displayName: Ingestion and Querying Ratelimiting
+          path: limits
+        - description: Global is used to define global rate limits.
+          displayName: Global Limit
+          path: limits.global
+        - description: Ingestion is used to define ingestion rate limits.
+          displayName: Ingestion Limit
+          path: limits.global.ingestion
+        - description: IngestionBurstSizeBytes defines the burst size (bytes) used
+            in ingestion.
+          displayName: Ingestion Burst Size in Bytes
+          path: limits.global.ingestion.ingestionBurstSizeBytes
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: IngestionRateLimitBytes defines the Per-user ingestion rate
+            limit (bytes) used in ingestion.
+          displayName: Ingestion Rate Limit in Bytes
+          path: limits.global.ingestion.ingestionRateLimitBytes
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: MaxBytesPerTrace defines the maximum number of bytes of an
+            acceptable trace.
+          displayName: Max Bytes per Trace
+          path: limits.global.ingestion.maxBytesPerTrace
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: MaxTracesPerUser defines the maximum number of traces a user
+            can send.
+          displayName: Max Traces per User
+          path: limits.global.ingestion.maxTracesPerUser
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: Query is used to define query rate limits.
+          displayName: Query Limit
+          path: limits.global.query
+        - description: MaxBytesPerTagValues defines the maximum size in bytes of a
+            tag-values query.
+          displayName: Max Tags per User
+          path: limits.global.query.maxBytesPerTagValues
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: |-
+            DEPRECATED. MaxSearchBytesPerTrace defines the maximum size of search data for a single
+            trace in bytes.
+            default: `0` to disable.
+          displayName: Max Traces per User
+          path: limits.global.query.maxSearchBytesPerTrace
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: |-
+            MaxSearchDuration defines the maximum allowed time range for a search.
+            If this value is not set, then spec.search.maxDuration is used.
+          displayName: Max Search Duration per User
+          path: limits.global.query.maxSearchDuration
+        - description: PerTenant is used to define rate limits per tenant.
+          displayName: Tenant Limits
+          path: limits.perTenant
+        - description: Ingestion is used to define ingestion rate limits.
+          displayName: Ingestion Limit
+          path: limits.perTenant.ingestion
+        - description: IngestionBurstSizeBytes defines the burst size (bytes) used
+            in ingestion.
+          displayName: Ingestion Burst Size in Bytes
+          path: limits.perTenant.ingestion.ingestionBurstSizeBytes
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: IngestionRateLimitBytes defines the Per-user ingestion rate
+            limit (bytes) used in ingestion.
+          displayName: Ingestion Rate Limit in Bytes
+          path: limits.perTenant.ingestion.ingestionRateLimitBytes
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: MaxBytesPerTrace defines the maximum number of bytes of an
+            acceptable trace.
+          displayName: Max Bytes per Trace
+          path: limits.perTenant.ingestion.maxBytesPerTrace
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: MaxTracesPerUser defines the maximum number of traces a user
+            can send.
+          displayName: Max Traces per User
+          path: limits.perTenant.ingestion.maxTracesPerUser
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: Query is used to define query rate limits.
+          displayName: Query Limit
+          path: limits.perTenant.query
+        - description: MaxBytesPerTagValues defines the maximum size in bytes of a
+            tag-values query.
+          displayName: Max Tags per User
+          path: limits.perTenant.query.maxBytesPerTagValues
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: |-
+            DEPRECATED. MaxSearchBytesPerTrace defines the maximum size of search data for a single
+            trace in bytes.
+            default: `0` to disable.
+          displayName: Max Traces per User
+          path: limits.perTenant.query.maxSearchBytesPerTrace
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:number
+        - description: |-
+            MaxSearchDuration defines the maximum allowed time range for a search.
+            If this value is not set, then spec.search.maxDuration is used.
+          displayName: Max Search Duration per User
+          path: limits.perTenant.query.maxSearchDuration
+        - description: |-
+            ManagementState defines if the CR should be managed by the operator or not.
+            Default is managed.
+          displayName: Management State
+          path: managementState
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:Managed
+          - urn:alm:descriptor:com.tectonic.ui:select:Unmanaged
+        - description: NetworkPolicySpec defines how network policies are handled.
+          displayName: Network Policy
+          path: networkPolicy
+        - description: Enabled determines whether network policies are generated for
+            the operands.
+          displayName: Enable Network Policies
+          path: networkPolicy.enabled
+        - description: ObservabilitySpec defines how telemetry data gets handled.
+          displayName: Observability
+          path: observability
+        - description: Grafana defines the Grafana configuration for operands.
+          displayName: Grafana Config
+          path: observability.grafana
+        - description: CreateDatasource specifies if a Grafana Datasource should be
+            created for Tempo.
+          displayName: Create Datasource for Tempo
+          path: observability.grafana.createDatasource
+        - description: InstanceSelector specifies the Grafana instance where the datasource
+            should be created.
+          displayName: Create CreateDatasource for Tempo
+          path: observability.grafana.instanceSelector
+        - description: Metrics defines the metrics configuration for operands.
+          displayName: Metrics Config
+          path: observability.metrics
+        - description: CreatePrometheusRules specifies if Prometheus rules for alerts
+            should be created for Tempo components.
+          displayName: Create PrometheusRules for Tempo components
+          path: observability.metrics.createPrometheusRules
+        - description: CreateServiceMonitors specifies if ServiceMonitors should be
+            created for Tempo components.
+          displayName: Create ServiceMonitors for Tempo components
+          path: observability.metrics.createServiceMonitors
+        - description: ExtraPrometheusRuleLabels defines additional labels for the
+            PrometheusRule objects.
+          displayName: Extra PrometheusRule Labels
+          path: observability.metrics.extraPrometheusRuleLabels
+        - description: ExtraServiceMonitorLabels defines additional labels for the
+            ServiceMonitor objects.
+          displayName: Extra ServiceMonitor Labels
+          path: observability.metrics.extraServiceMonitorLabels
+        - description: Tracing defines a config for operands.
+          displayName: Tracing Config
+          path: observability.tracing
+        - description: |-
+            JaegerAgentEndpoint defines the jaeger endpoint data gets send to.
+            Deprecated: in favor of OTLPHttpEndpoint.
+          displayName: Jaeger-Agent-Endpoint
+          path: observability.tracing.jaeger_agent_endpoint
+        - description: |-
+            OTLPHttpEndpoint defines the OTLP/http endpoint data gets send to.
+            For example, "http://localhost:4320".
+            The default OTLP/http port 4318 collides with the distributor ports, therefore it is recommended to use a different port
+            on the sidecar injected to the Tempo (e.g. 4320).
+          displayName: OTLP-HTTP-Endpoint
+          path: observability.tracing.otlp_http_endpoint
+        - description: |-
+            SamplingFraction defines the sampling ratio. Valid values are 0 to 1.
+            The SamplingFraction has to be defined to enable tracing.
+          displayName: Sampling Fraction
+          path: observability.tracing.sampling_fraction
+        - description: The replication factor is a configuration setting that determines
+            how many ingesters need to acknowledge the data from the distributors
+            before accepting a span.
+          displayName: Replication Factor
+          path: replicationFactor
+        - description: Resources defines resources configuration.
+          displayName: Resources
+          path: resources
+        - description: |-
+            The total amount of resources for Tempo instance.
+            The operator autonomously splits resources between deployed Tempo components.
+            Only limits are supported, the operator calculates requests automatically.
+            See http://github.com/grafana/tempo/issues/1540.
+          displayName: Resource Requirements
+          path: resources.total
+        - description: |-
+            Retention period defined by dataset.
+            User can specify how long data should be stored.
+          displayName: Retention Period
+          path: retention
+        - description: Global is used to configure global retention.
+          displayName: Global Retention
+          path: retention.global
+        - description: |-
+            Traces defines retention period. Supported parameter suffixes are "s", "m" and "h".
+            example: 336h
+            default: value is 48h.
+          displayName: Trace Retention Period
+          path: retention.global.traces
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: PerTenant is used to configure retention per tenant.
+          displayName: PerTenant Retention
+          path: retention.perTenant
+        - description: |-
+            Traces defines retention period. Supported parameter suffixes are "s", "m" and "h".
+            example: 336h
+            default: value is 48h.
+          displayName: Trace Retention Period
+          path: retention.perTenant.traces
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:text
+        - description: SearchSpec control the configuration for the search capabilities.
+          displayName: Search configuration options
+          path: search
+        - description: 'Limit used for search requests if none is set by the caller
+            (default: 20)'
+          displayName: Limit used for search requests if none is set by the caller,
+            this limit the number of traces returned by the query
+          path: search.defaultResultLimit
+        - description: 'The maximum allowed time range for a search, default: 0s which
+            means unlimited.'
+          displayName: Max search time range allowed
+          path: search.maxDuration
+        - description: |-
+            The maximum allowed value of the limit parameter on search requests. If the search request limit parameter
+            exceeds the value configured here it will be set to the value configured here.
+            The default value of 0 disables this limit.
+          displayName: The maximum allowed value of the limit parameter on search
+            requests, this determine the max number of traces allowed to be returned
+          path: search.maxResultLimit
+        - description: ServiceAccount defines the service account to use for all tempo
+            components.
+          displayName: Service Account
+          path: serviceAccount
+        - description: |-
+            Size defines a predefined deployment size profile for this TempoStack.
+            The operator will apply pre-tested resource configurations based on the selected size.
+            When not set, resources are determined by spec.resources.total or component-level overrides.
+            Size also sets a default replication factor (1 for demo, 2 for others) if not explicitly specified.
+          displayName: Deployment Size
+          path: size
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:1x.demo
+          - urn:alm:descriptor:com.tectonic.ui:select:1x.pico
+          - urn:alm:descriptor:com.tectonic.ui:select:1x.extra-small
+          - urn:alm:descriptor:com.tectonic.ui:select:1x.small
+          - urn:alm:descriptor:com.tectonic.ui:select:1x.medium
+        - description: |-
+            Storage defines the spec for the object storage endpoint to store traces.
+            User is required to create secret and supply it.
+          displayName: Object Storage
+          path: storage
+        - description: |-
+            Secret for object storage authentication.
+            Name of a secret in the same namespace as the TempoStack custom resource.
+          displayName: Object Storage Secret
+          path: storage.secret
+        - description: Name of a secret in the namespace configured for object storage
+            secrets.
+          displayName: Object Storage Secret Name
+          path: storage.secret.name
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: Type of object storage that should be used
+          displayName: Object Storage Secret Type
+          path: storage.secret.type
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:azure
+          - urn:alm:descriptor:com.tectonic.ui:select:gcs
+          - urn:alm:descriptor:com.tectonic.ui:select:s3
+        - description: TLS configuration for reaching the object storage endpoint.
+          displayName: TLS Config
+          path: storage.tls
+        - description: |-
+            CA is the name of a ConfigMap containing a CA certificate (service-ca.crt).
+            It needs to be in the same namespace as the Tempo custom resource.
+          displayName: CA ConfigMap
+          path: storage.tls.caName
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:ConfigMap
+        - description: |-
+            Cert is the name of a Secret containing a certificate (tls.crt) and private key (tls.key).
+            It needs to be in the same namespace as the Tempo custom resource.
+          displayName: Certificate Secret
+          path: storage.tls.certName
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: MinVersion defines the minimum acceptable TLS version.
+          displayName: Min TLS Version
+          path: storage.tls.minVersion
+        - description: StorageClassName for PVCs used by ingester. Defaults to nil
+            (default storage class in the cluster).
+          displayName: StorageClassName for PVCs
+          path: storageClassName
+        - description: StorageSize for PVCs used by ingester. Defaults to 10Gi.
+          displayName: Storage size for PVCs
+          path: storageSize
+        - description: Template defines requirements for a set of tempo components.
+          displayName: Tempo Component Templates
+          path: template
+        - description: Compactor defines the tempo compactor component spec.
+          displayName: Compactor pods
+          path: template.compactor
+        - description: NodeSelector defines the simple form of the node-selection
+            constraint.
+          displayName: Node Selector
+          path: template.compactor.nodeSelector
+        - description: PodSecurityContext defines security context will be applied
+            to all pods of this component.
+          displayName: PodSecurityContext
+          path: template.compactor.podSecurityContext
+        - description: Replicas defines the number of replicas to be created for this
+            component.
+          displayName: Component Replicas
+          path: template.compactor.replicas
+        - description: Resources defines resources for this component, this will override
+            the calculated resources derived from total
+          displayName: Resources
+          path: template.compactor.resources
+        - description: Tolerations defines component-specific pod tolerations.
+          displayName: Tolerations
+          path: template.compactor.tolerations
+        - description: Distributor defines the distributor component spec.
+          displayName: Distributor pods
+          path: template.distributor
+        - description: NodeSelector defines the simple form of the node-selection
+            constraint.
+          displayName: Node Selector
+          path: template.distributor.nodeSelector
+        - description: PodSecurityContext defines security context will be applied
+            to all pods of this component.
+          displayName: PodSecurityContext
+          path: template.distributor.podSecurityContext
+        - description: Replicas defines the number of replicas to be created for this
+            component.
+          displayName: Component Replicas
+          path: template.distributor.replicas
+        - description: Resources defines resources for this component, this will override
+            the calculated resources derived from total
+          displayName: Resources
+          path: template.distributor.resources
+        - description: |-
+            TLS defines TLS configuration for distributor receivers
+
+
+            If openshift feature flag `servingCertsService` is enabled and TLS is enabled but no
+            certName or caName is specified, OpenShift service serving certificates will  be used.
+          displayName: TLS
+          path: template.distributor.tls
+        - description: |-
+            CA is the name of a ConfigMap containing a CA certificate (service-ca.crt).
+            It needs to be in the same namespace as the Tempo custom resource.
+          displayName: CA ConfigMap
+          path: template.distributor.tls.caName
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:ConfigMap
+        - description: |-
+            Cert is the name of a Secret containing a certificate (tls.crt) and private key (tls.key).
+            It needs to be in the same namespace as the Tempo custom resource.
+          displayName: Certificate Secret
+          path: template.distributor.tls.certName
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: MinVersion defines the minimum acceptable TLS version.
+          displayName: Min TLS Version
+          path: template.distributor.tls.minVersion
+        - description: Tolerations defines component-specific pod tolerations.
+          displayName: Tolerations
+          path: template.distributor.tolerations
+        - description: Gateway defines the tempo gateway spec.
+          displayName: Gateway pods
+          path: template.gateway
+        - displayName: Enabled
+          path: template.gateway.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Ingress defines gateway Ingress options.
+          displayName: Gateway Ingress Settings
+          path: template.gateway.ingress
+        - description: Annotations defines the annotations of the Ingress object.
+          displayName: Annotations
+          path: template.gateway.ingress.annotations
+        - description: Host defines the hostname of the Ingress object.
+          displayName: Host
+          path: template.gateway.ingress.host
+        - description: Route defines the options for the OpenShift route.
+          displayName: Route Configuration
+          path: template.gateway.ingress.route
+        - description: |-
+            Termination defines the termination type.
+            The default is "edge".
+          displayName: TLS Termination Policy
+          path: template.gateway.ingress.route.termination
+        - description: |-
+            Type defines the type of Ingress for the Jaeger Query UI.
+            Currently ingress, route and none are supported.
+          displayName: Type
+          path: template.gateway.ingress.type
+        - description: NodeSelector defines the simple form of the node-selection
+            constraint.
+          displayName: Node Selector
+          path: template.gateway.nodeSelector
+        - description: PodSecurityContext defines security context will be applied
+            to all pods of this component.
+          displayName: PodSecurityContext
+          path: template.gateway.podSecurityContext
+        - description: RBAC defines query RBAC options.
+          displayName: Query RBAC Settings
+          path: template.gateway.rbac
+        - description: Enabled defines if the query RBAC should be enabled.
+          displayName: Query RBAC Enabled
+          path: template.gateway.rbac.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: Replicas defines the number of replicas to be created for this
+            component.
+          displayName: Component Replicas
+          path: template.gateway.replicas
+        - description: Resources defines resources for this component, this will override
+            the calculated resources derived from total
+          displayName: Resources
+          path: template.gateway.resources
+        - description: Tolerations defines component-specific pod tolerations.
+          displayName: Tolerations
+          path: template.gateway.tolerations
+        - description: Ingester defines the ingester component spec.
+          displayName: Ingester pods
+          path: template.ingester
+        - description: NodeSelector defines the simple form of the node-selection
+            constraint.
+          displayName: Node Selector
+          path: template.ingester.nodeSelector
+        - description: PodSecurityContext defines security context will be applied
+            to all pods of this component.
+          displayName: PodSecurityContext
+          path: template.ingester.podSecurityContext
+        - description: Replicas defines the number of replicas to be created for this
+            component.
+          displayName: Component Replicas
+          path: template.ingester.replicas
+        - description: Resources defines resources for this component, this will override
+            the calculated resources derived from total
+          displayName: Resources
+          path: template.ingester.resources
+        - description: Tolerations defines component-specific pod tolerations.
+          displayName: Tolerations
+          path: template.ingester.tolerations
+        - description: Querier defines the querier component spec.
+          displayName: Querier pods
+          path: template.querier
+        - description: NodeSelector defines the simple form of the node-selection
+            constraint.
+          displayName: Node Selector
+          path: template.querier.nodeSelector
+        - description: PodSecurityContext defines security context will be applied
+            to all pods of this component.
+          displayName: PodSecurityContext
+          path: template.querier.podSecurityContext
+        - description: Replicas defines the number of replicas to be created for this
+            component.
+          displayName: Component Replicas
+          path: template.querier.replicas
+        - description: Resources defines resources for this component, this will override
+            the calculated resources derived from total
+          displayName: Resources
+          path: template.querier.resources
+        - description: Tolerations defines component-specific pod tolerations.
+          displayName: Tolerations
+          path: template.querier.tolerations
+        - description: TempoQueryFrontendSpec defines the query frontend spec.
+          displayName: Query Frontend pods
+          path: template.queryFrontend
+        - description: JaegerQuery defines options specific to the Jaeger Query component.
+          displayName: Jaeger Query Settings
+          path: template.queryFrontend.jaegerQuery
+        - description: Authentication defines the options for the oauth proxy used
+            to protect jaeger UI
+          displayName: Jaeger UI authentication configuration
+          path: template.queryFrontend.jaegerQuery.authentication
+        - description: |-
+            Resources defines the compute resource requirements of the OAuth Proxy container.
+            The OAuth Proxy performs authentication and authorization of incoming requests to Jaeger UI when multi-tenancy is disabled.
+          displayName: Resources
+          path: template.queryFrontend.jaegerQuery.authentication.resources
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:resourceRequirements
+        - description: |-
+            SAR defines the SAR to be used in the oauth-proxy
+            default is "{"namespace": "<tempo_stack_namespace>", "resource": "pods", "verb": "get"}
+          displayName: SAR
+          path: template.queryFrontend.jaegerQuery.authentication.sar
+        - description: Enabled defines if the Jaeger Query component should be created.
+          displayName: Enable Jaeger Query UI
+          path: template.queryFrontend.jaegerQuery.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: |-
+            FindTracesConcurrentRequests defines how many concurrent request a single trace search can submit (defaults querier.replicas*2).
+            The search for traces in Jaeger submits limit+1 requests. First requests finds trace IDs and then it fetches
+            entire traces by ID. This property allows Jaeger to fetch traces in parallel.
+            Note that by default a single Tempo querier can process 20 concurrent search jobs.
+            Increasing this property might require scaling up querier instances, especially on error "job queue full"
+            See also Tempo's extraConfig:
+            querier.max_concurrent_queries (20 default)
+            query_frontend.max_outstanding_per_tenant: (2000 default). Increase if the query-frontend returns 429
+          displayName: FindTracesConcurrentRequests
+          path: template.queryFrontend.jaegerQuery.findTracesConcurrentRequests
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:advanced
+        - description: Ingress defines the options for the Jaeger Query ingress.
+          displayName: Jaeger Query UI Ingress Settings
+          path: template.queryFrontend.jaegerQuery.ingress
+        - description: Annotations defines the annotations of the Ingress object.
+          displayName: Annotations
+          path: template.queryFrontend.jaegerQuery.ingress.annotations
+        - description: Host defines the hostname of the Ingress object.
+          displayName: Host
+          path: template.queryFrontend.jaegerQuery.ingress.host
+        - description: Route defines the options for the OpenShift route.
+          displayName: Route Configuration
+          path: template.queryFrontend.jaegerQuery.ingress.route
+        - description: |-
+            Termination defines the termination type.
+            The default is "edge".
+          displayName: TLS Termination Policy
+          path: template.queryFrontend.jaegerQuery.ingress.route.termination
+        - description: |-
+            Type defines the type of Ingress for the Jaeger Query UI.
+            Currently ingress, route and none are supported.
+          displayName: Type
+          path: template.queryFrontend.jaegerQuery.ingress.type
+        - description: MonitorTab defines the monitor tab configuration.
+          displayName: Jaeger Query UI Monitor Tab Settings
+          path: template.queryFrontend.jaegerQuery.monitorTab
+        - description: |-
+            Enabled enables the monitor tab in the Jaeger console.
+            The PrometheusEndpoint must be configured to enable this feature.
+          displayName: Enabled
+          path: template.queryFrontend.jaegerQuery.monitorTab.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: |-
+            PrometheusEndpoint defines the endpoint to the Prometheus instance that contains the span rate, error, and duration (RED) metrics.
+            For instance on OpenShift this is set to https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
+          displayName: Prometheus endpoint
+          path: template.queryFrontend.jaegerQuery.monitorTab.prometheusEndpoint
+        - description: REDMetricsNamespace defines the a prefix used retrieve span
+            rate, error, and duration (RED) metrics.
+          displayName: RED Metric Namespace
+          path: template.queryFrontend.jaegerQuery.monitorTab.redMetricsNamespace
+        - description: Resources defines resources for this component, this will override
+            the calculated resources derived from total
+          displayName: Resources
+          path: template.queryFrontend.jaegerQuery.resources
+        - description: ServicesQueryDuration defines how long the services will be
+            available in the services list
+          displayName: ServicesQueryDuration
+          path: template.queryFrontend.jaegerQuery.servicesQueryDuration
+        - description: TempoQuery defines options specific to the Tempoo Query component.
+          displayName: Tempo Query Settings
+          path: template.queryFrontend.jaegerQuery.tempoQuery
+        - description: Resources defines resources for this component, this will override
+            the calculated resources derived from total
+          displayName: Resources
+          path: template.queryFrontend.jaegerQuery.tempoQuery.resources
+        - description: |-
+            MCPServer defines the MCP (Model Context Protocol) server configuration.
+            The MCP server allows AI assistants to query tracing data.
+          displayName: MCP Server Settings
+          path: template.queryFrontend.mcpServer
+        - description: Enabled defines if the MCP (Model Context Protocol) server
+            should be enabled.
+          displayName: Enable MCP Server
+          path: template.queryFrontend.mcpServer.enabled
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:booleanSwitch
+        - description: NodeSelector defines the simple form of the node-selection
+            constraint.
+          displayName: Node Selector
+          path: template.queryFrontend.nodeSelector
+        - description: PodSecurityContext defines security context will be applied
+            to all pods of this component.
+          displayName: PodSecurityContext
+          path: template.queryFrontend.podSecurityContext
+        - description: Replicas defines the number of replicas to be created for this
+            component.
+          displayName: Component Replicas
+          path: template.queryFrontend.replicas
+        - description: Resources defines resources for this component, this will override
+            the calculated resources derived from total
+          displayName: Resources
+          path: template.queryFrontend.resources
+        - description: Tolerations defines component-specific pod tolerations.
+          displayName: Tolerations
+          path: template.queryFrontend.tolerations
+        - description: Tenants defines the per-tenant authentication and authorization
+            spec.
+          displayName: Tenants Configuration
+          path: tenants
+        - description: Authentication defines the tempo-gateway component authentication
+            configuration spec per tenant.
+          displayName: Authentication
+          path: tenants.authentication
+        - description: OIDC defines the spec for the OIDC tenant's authentication.
+          displayName: OIDC Configuration
+          path: tenants.authentication[0].oidc
+        - description: IssuerURL defines the URL for issuer.
+          displayName: Issuer URL
+          path: tenants.authentication[0].oidc.issuerURL
+        - description: RedirectURL defines the URL for redirect.
+          displayName: Redirect URL
+          path: tenants.authentication[0].oidc.redirectURL
+        - description: Secret defines the spec for the clientID, clientSecret and
+            issuerCAPath for tenant's authentication.
+          displayName: Tenant Secret
+          path: tenants.authentication[0].oidc.secret
+        - description: Name of a secret in the namespace configured for tenant secrets.
+          displayName: Tenant Secret Name
+          path: tenants.authentication[0].oidc.secret.name
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes:Secret
+        - description: |-
+            TenantID defines a universally unique identifier of the tenant.
+            Unlike the tenantName, which must be unique at a given time, the tenantId must be unique over the entire lifetime of the Tempo deployment.
+            Tempo uses this ID to prefix objects in the object storage.
+          displayName: Tenant ID
+          path: tenants.authentication[0].tenantId
+        - description: |-
+            TenantName defines a human readable, unique name of the tenant.
+            The value of this field must be specified in the X-Scope-OrgID header and in the resources field of a ClusterRole to identify the tenant.
+          displayName: Tenant Name
+          path: tenants.authentication[0].tenantName
+        - description: Authorization defines the tempo-gateway component authorization
+            configuration spec per tenant.
+          displayName: Authorization
+          path: tenants.authorization
+        - description: RoleBindings defines configuration to bind a set of roles to
+            a set of subjects.
+          displayName: Static Role Bindings
+          path: tenants.authorization.roleBindings
+        - description: Roles defines a set of permissions to interact with a tenant.
+          displayName: Static Roles
+          path: tenants.authorization.roles
+        - description: Mode defines the multitenancy mode.
+          displayName: Mode
+          path: tenants.mode
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:select:static
+          - urn:alm:descriptor:com.tectonic.ui:select:openshift
+        statusDescriptors:
+        - description: Distributor is a map to the per pod status of the distributor
+            deployment
+          displayName: Distributor
+          path: components.distributor
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:podStatuses
+        - description: Ingester is a map to the per pod status of the ingester statefulset
+          displayName: Ingester
+          path: components.ingester
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:podStatuses
+        - description: Querier is a map to the per pod status of the querier deployment
+          displayName: Querier
+          path: components.querier
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:podStatuses
+        - description: QueryFrontend is a map to the per pod status of the query frontend
+            deployment
+          displayName: Query Frontend
+          path: components.queryFrontend
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:podStatuses
+        - description: Compactor is a map to the pod status of the compactor pod.
+          displayName: Compactor
+          path: components.compactor
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:podStatuses
+        - description: Gateway is a map to the per pod status of the query frontend
+            deployment
+          displayName: Gateway
+          path: components.gateway
+          x-descriptors:
+          - urn:alm:descriptor:com.tectonic.ui:podStatuses
+        - description: Conditions of the Tempo deployment health.
+          displayName: Conditions
+          path: conditions
+          x-descriptors:
+          - urn:alm:descriptor:io.kubernetes.conditions
+        version: v1alpha1
+    description: |-
+      Red Hat OpenShift distributed tracing platform based on Tempo. Tempo is an open-source, easy-to-use, and highly scalable distributed tracing backend. It provides observability for microservices architectures by allowing developers to track requests as they flow through distributed systems. Tempo is optimized to handle large volumes of trace data and is designed to be highly performant even under heavy loads.
+      It can ingest common open source tracing protocols including Jaeger, Zipkin, and OpenTelemetry and requires only object storage to operate.
+
+      The Tempo Operator supports Tempo deployments in Microservices mode (`TempoStack` CR) and Monolithic mode (`TempoMonolithic` CR).
+
+      ### Core capabilities
+      Tempo is used for monitoring and troubleshooting microservices-based distributed systems, including:
+      * Distributed transaction monitoring
+      * Root cause analysis
+      * Performance / latency optimization
+
+      ### Operator features
+      * **Resource Limits** - Specify overall resource requests and limits in the `TempoStack` CR; the operator assigns fractions of it to each component
+      * **AuthN and AuthZ** - Supports OpenID Control (OIDC) and role-based access control (RBAC)
+      * **Managed upgrades** - Updating the operator will automatically update all managed Tempo clusters
+      * **Multitenancy** - Multiple tenants can send traces to the same Tempo cluster
+      * **mTLS** - Communication between the Tempo components can be secured via mTLS
+      * **Jaeger UI** - Traces can be visualized in Jaeger UI and exposed via Ingress or OpenShift Route
+      * **Observability** - The operator and `TempoStack` operands expose telemetry (metrics, traces) and integrate with Prometheus `ServiceMonitor` and `PrometheusRule`
+
+      ### Before you start
+      `TempoStack` requires object storage to store its traces. `TempoMonolithic` can store traces in-memory, in a Persistent Volume and in object storage.
+      Please ensure that your system has a compatible object storage solution that is supported, such as OpenShift Data Foundation, Minio, AWS S3, Azure Storage, or Google Cloud Storage.
+
+      ### Examples
+      There is a list of examples to help you deploy different configurations in [this GitHub repository](https://github.com/os-observability/redhat-rhosdt-samples).
+
+      ### Support & Troubleshooting
+      Tempo Operator is available and supported as part of a Red Hat OpenShift subscription.
+      Checking the [Red Hat Documentation](https://docs.redhat.com/en/documentation/openshift_container_platform/latest/html/distributed_tracing) is recommended when installing, configuring, and managing the Operator and instances.
+    displayName: Tempo Operator
+    installModes:
+    - supported: false
+      type: OwnNamespace
+    - supported: false
+      type: SingleNamespace
+    - supported: false
+      type: MultiNamespace
+    - supported: true
+      type: AllNamespaces
+    keywords:
+    - tempo
+    - tracing
+    - observability
+    - monitoring
+    - database
+    labels:
+      operatorframework.io/arch.amd64: supported
+      operatorframework.io/arch.arm64: supported
+      operatorframework.io/arch.ppc64le: supported
+      operatorframework.io/arch.s390x: supported
+      operatorframework.io/os.linux: supported
+    links:
+    - name: Tempo Operator
+      url: https://github.com/grafana/tempo-operator
+    maintainers:
+    - email: support@redhat.com
+      name: Red Hat support
+    maturity: alpha
+    minKubeVersion: 1.25.0
+    provider:
+      name: Red Hat
+relatedImages:
+- image: registry.redhat.io/rhosdt/tempo-operator-bundle@sha256:d180bac53d873bba131cedd40db06cd784d8dc4795d9bff85a6b33921cc1dd9c
+  name: ""
+- image: registry.redhat.io/openshift4/ose-oauth-proxy@sha256:6bcfa981a7a75c242a16afa6dab36bf6e3b8a1442fa863875919ad551f48eceb
+  name: ose-oauth-proxy
+- image: registry.redhat.io/rhosdt/tempo-gateway-opa-rhel9@sha256:c5bacd8f492e4b2482c5fb52b1b64ef1fcc6a3db43185e2a68ead7bb8f50f917
+  name: gateway-opa
+- image: registry.redhat.io/rhosdt/tempo-gateway-rhel9@sha256:5d5591d8c0639f2fe65eaba1d96c7127cfa538739ff6043ec408fb92a42537cb
+  name: gateway
+- image: registry.redhat.io/rhosdt/tempo-jaeger-query-rhel9@sha256:8adf1d5471eb789b74a83aef91273895bb3170871c665a4511d9f2867874ada1
+  name: jaeger-query
+- image: registry.redhat.io/rhosdt/tempo-query-rhel9@sha256:dd811d521e8334c831175d7a5e1202ed0cedaaa3ed09612280ebbe5f00178ba1
+  name: tempo-query
+- image: registry.redhat.io/rhosdt/tempo-rhel9-operator@sha256:90c692e25861726382dfe60393d3ec57e3bad6037927a9d07ee15efa66dbc07e
+  name: operator
+- image: registry.redhat.io/rhosdt/tempo-rhel9@sha256:91b5138e11f428e1f8c77aa9651297084701cdbe799b8553235d70aa5b0afb83
   name: tempo
 schema: olm.bundle
 ---


### PR DESCRIPTION
## Summary
- The bundle pullspec in `catalog/catalog.env` was pointing to `sha256:acb976...` which contains version `0.20.0-1`
- Updated to `sha256:d180bac...` which contains the correct version `0.20.0-3`, built from bundle commit 529d788
- This fixes the `update-catalog` GitHub Action failure: `duplicate bundle "tempo-operator.v0.20.0-1"`

## Test plan
- [ ] Verify the `update-catalog` GitHub Action passes on this PR
- [ ] Verify generated catalog files contain `v0.20.0-3` entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)