### PR TITLE
Add OLMv1 bundle compliance checks and 4.21+ e2e pipeline

### DIFF
--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-21-olmv1.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-21-olmv1.yaml
@@ -1,0 +1,773 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/task: "[tempo-install, operators-install, tempo-e2e-tests]"
+  name: tempo-operator-e2e-tests-pipeline
+spec:
+  description: |
+    OLMv1 end-to-end pipeline for the Tempo operator on OCP 4.21+.
+
+    Triggered on snapshots of the FBC application (e.g. tempo-fbc-v4-21-main)
+    so the FBC image under test is present in the snapshot. The pipeline
+    provisions an ephemeral 4.21+ cluster, applies the FBC as a ClusterCatalog,
+    installs the operator via a ClusterExtension (OLMv1, not `operator-sdk run
+    bundle`), installs dependent operators (still on OLMv0), runs the tempo
+    e2e suite, and deprovisions.
+
+    Differs from tempo-operator-e2e-test-pipeline-4-18.yaml only in:
+      - cluster version prefix (4.21. vs 4.18.)
+      - tempo-install applies a ClusterCatalog + ClusterExtension instead of
+        running `operator-sdk run bundle`
+      - tempo-install reads the FBC component (not the bundle component) from
+        $SNAPSHOT and applies it as the ClusterCatalog source
+
+    OLMv1 references:
+      https://docs.okd.io/latest/extensions/ce/olmv1-supported-extensions.html
+      https://operator-framework.github.io/operator-controller/project/olmv1_limitations/
+  params:
+    - name: SNAPSHOT
+      description: 'The JSON string representing the snapshot of the application under test.'
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: test-name
+      description: 'The name of the test corresponding to a defined Konflux integration test.'
+      default: 'tempo-operator-e2e-tests'
+    - name: namespace
+      description: 'Namespace to run tests in'
+      default: 'openshift-tempo-operator'
+    - name: jaeger_query_version
+      description: Version of Jaeger Query
+    - name: operator_version
+      description: Version of the operator
+    - name: operator_tempo_version
+      description: Version of the Tempo operator
+    - name: operator_tempo_query_version
+      description: Version of the Tempo query
+    - name: operand_tempo_version
+      description: Version of the Tempo operand
+    - name: tempo_tests_branch
+      description: "The repository branch from which to run the tests"
+    - name: skip_tests
+      description: "Tests to be skipped seperated with a space delimiter"
+    - name: rhosdt_version
+      description: "RHOSDT product version used to tag RapiDAST scan results in GCS"
+  tasks:
+    - name: parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+    - name: eaas-provision-space
+      runAfter:
+        - parse-metadata
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: provision-cluster
+      runAfter:
+        - eaas-provision-space
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "4.21."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: "m5.2xlarge"
+              - name: timeout
+                value: "40m"
+              - name: fips
+                value: "false"
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/rhosdt/tempo-rhel9-operator
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-operator
+                  - source: registry.redhat.io/rhosdt/tempo-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo
+                  - source: registry.redhat.io/rhosdt/tempo-query-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-query
+                  - source: registry.redhat.io/rhosdt/tempo-jaeger-query-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-jaeger-query
+                  - source: registry.redhat.io/rhosdt/tempo-gateway-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-gateway
+                  - source: registry.redhat.io/rhosdt/tempo-gateway-opa-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-opa
+                  - source: registry.redhat.io/rhosdt/tempo-operator-bundle
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-bundle
+    - name: tempo-install
+      description: Task to install bundle onto ephemeral namespace
+      runAfter:
+        - provision-cluster
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: namespace
+          value: "$(params.namespace)"
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+          - name: namespace
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: install-operator
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: KONFLUX_COMPONENT_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/component']
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
+            script: |
+              #!/usr/bin/env bash
+              set -euo pipefail
+
+              # Install the Tempo operator under OLMv1 by:
+              #   1. Resolving the FBC image from the snapshot.
+              #      (Test runs on the FBC application's snapshot, so
+              #      KONFLUX_COMPONENT_NAME is the FBC component, e.g.
+              #      tempo-fbc-v4-21-main.)
+              #   2. Applying a ClusterCatalog backed by that FBC image.
+              #   3. Creating an installer ServiceAccount with cluster-admin.
+              #      TODO: replace with minimal RBAC derived from the CSV's
+              #      clusterPermissions/permissions once we have a generator.
+              #   4. Applying a ClusterExtension referencing the
+              #      tempo-product package on the stable channel.
+              #   5. Waiting for ClusterExtension Installed=True and the
+              #      operator deployment to become Available.
+              # Refs:
+              #   https://docs.okd.io/latest/extensions/ce/olmv1-supported-extensions.html
+              #   https://operator-framework.github.io/operator-controller/project/olmv1_limitations/
+
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+
+              echo "Create namespace to install Tempo Operator"
+              oc create namespace $(params.namespace)
+              oc label namespaces $(params.namespace) openshift.io/cluster-monitoring=true --overwrite=true
+
+              echo "Resolve FBC image from snapshot"
+              echo "KONFLUX_COMPONENT_NAME=${KONFLUX_COMPONENT_NAME}"
+              FBC_IMAGE="$(jq -r --arg c "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $c) | .containerImage' <<< "$SNAPSHOT")"
+              if [ -z "${FBC_IMAGE}" ] || [ "${FBC_IMAGE}" = "null" ]; then
+                echo "ERROR: could not resolve FBC image for component '${KONFLUX_COMPONENT_NAME}' from snapshot" >&2
+                jq . <<< "$SNAPSHOT" >&2
+                exit 1
+              fi
+              echo "FBC_IMAGE=${FBC_IMAGE}"
+
+              echo "Apply ClusterCatalog"
+              cat <<EOF | oc apply -f -
+              apiVersion: olm.operatorframework.io/v1
+              kind: ClusterCatalog
+              metadata:
+                name: tempo-test-catalog
+              spec:
+                source:
+                  type: Image
+                  image:
+                    ref: ${FBC_IMAGE}
+                    pollIntervalMinutes: 0
+              EOF
+
+              echo "Wait for ClusterCatalog to be Serving"
+              oc wait --for=condition=Serving --timeout=5m clustercatalog/tempo-test-catalog
+
+              echo "Create installer ServiceAccount + cluster-admin binding"
+              # TODO(OLMv1 RBAC hardening): replace cluster-admin with a
+              # minimal role synthesized from the CSV's permissions /
+              # clusterPermissions. Tracked alongside the realistic-RBAC
+              # path discussed in TRACING-5751.
+              cat <<EOF | oc apply -f -
+              apiVersion: v1
+              kind: ServiceAccount
+              metadata:
+                name: tempo-installer
+                namespace: $(params.namespace)
+              ---
+              apiVersion: rbac.authorization.k8s.io/v1
+              kind: ClusterRoleBinding
+              metadata:
+                name: tempo-installer-cluster-admin
+              subjects:
+                - kind: ServiceAccount
+                  name: tempo-installer
+                  namespace: $(params.namespace)
+              roleRef:
+                apiGroup: rbac.authorization.k8s.io
+                kind: ClusterRole
+                name: cluster-admin
+              EOF
+
+              echo "Apply ClusterExtension"
+              cat <<EOF | oc apply -f -
+              apiVersion: olm.operatorframework.io/v1
+              kind: ClusterExtension
+              metadata:
+                name: tempo-operator
+              spec:
+                namespace: $(params.namespace)
+                serviceAccount:
+                  name: tempo-installer
+                source:
+                  sourceType: Catalog
+                  catalog:
+                    packageName: tempo-product
+                    channels:
+                      - stable
+              EOF
+
+              echo "Wait for ClusterExtension to install"
+              oc wait --for=condition=Installed=True --timeout=10m clusterextension/tempo-operator
+
+              echo "Wait for operator deployment to become Available"
+              oc wait --for=condition=Available --timeout=5m -n "$(params.namespace)" deployment tempo-operator-controller
+    - name: operators-install
+      description: Task to install dependent operators onto ephemeral namespace
+      runAfter:
+        - tempo-install
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: namespace
+          value: "$(params.namespace)"
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+          - name: namespace
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: install-operators
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: KONFLUX_TEMPO_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: konflux-tempo-access-token-read-only
+                    key: token
+              - name: KONFLUX_COMPONENT_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/component']
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
+            script: |
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+              
+              echo "Installing dependent operators"
+              export OPERATORS_INSTALL=https://raw.githubusercontent.com/os-observability/konflux-tempo/refs/heads/main/.tekton/integration-tests/resources/install.yaml
+              curl -H "Authorization: token $KONFLUX_TEMPO_TOKEN" -Lo /tmp/install.yaml "$OPERATORS_INSTALL"
+              oc apply -f /tmp/install.yaml
+
+              retry_count=30
+              sleep_duration=30
+
+              check_operator_installed() {
+                local operator=$1
+                local namespace=$2
+                local csv=""
+                local retries=0
+
+                for i in $(seq $retry_count); do
+                  if [[ -z "$csv" ]]; then
+                    csv=$(oc get subscription -n $namespace $operator -o jsonpath='{.status.installedCSV}')
+                  fi
+
+                  if [[ -z "$csv" ]]; then
+                    echo "Try ${i}/${retry_count}: can't get the $operator yet. Checking again in $sleep_duration seconds"
+                    sleep $sleep_duration
+                  else
+                    if [[ $(oc get csv -n $namespace $csv -o jsonpath='{.status.phase}') == "Succeeded" ]]; then
+                      echo "$operator is successfully installed in namespace $namespace"
+                      return 0
+                    else
+                      echo "Try ${i}/${retry_count}: $operator is not deployed yet. Checking again in $sleep_duration seconds"
+                      sleep $sleep_duration
+                    fi
+                  fi
+                done
+
+                echo "$operator installation failed after $retry_count retries in namespace $namespace."
+                return 1
+              }
+
+              echo "Checking installation status of operators..."
+              check_operator_installed "opentelemetry-product" openshift-opentelemetry-operator
+              check_operator_installed "kiali-ossm" openshift-operators
+              check_operator_installed "servicemeshoperator" openshift-operators
+              check_operator_installed "serverless-operator" openshift-serverless
+              echo "Operator installation check completed."
+    - name: check-tempo-version
+      description: The task checks Tempo operator and operand version details and image info
+      runAfter:
+        - tempo-install
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: namespace
+          value: "$(params.namespace)"
+        - name: JAEGER_QUERY_VERSION
+          value: "$(params.jaeger_query_version)"
+        - name: OPERATOR_VERSION
+          value: "$(params.operator_version)"
+        - name: OPERATOR_TEMPO_VERSION
+          value: "$(params.operator_tempo_version)"
+        - name: OPERATOR_TEMPO_QUERY_VERSION
+          value: "$(params.operator_tempo_query_version)"
+        - name: OPERAND_TEMPO_VERSION
+          value: "$(params.operand_tempo_version)"
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+          - name: namespace
+            type: string
+          - name: JAEGER_QUERY_VERSION
+            type: string
+          - name: OPERATOR_VERSION
+            type: string
+          - name: OPERATOR_TEMPO_VERSION
+            type: string
+          - name: OPERATOR_TEMPO_QUERY_VERSION
+            type: string
+          - name: OPERAND_TEMPO_VERSION
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: check-version
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: KONFLUX_TEMPO_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: konflux-tempo-access-token-read-only
+                    key: token
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
+            script: |
+              #!/bin/bash
+              set -eu
+
+              # Variables for strings to check
+              JAEGER_QUERY_VERSION=$(params.JAEGER_QUERY_VERSION)
+              OPERATOR_VERSION=$(params.OPERATOR_VERSION)
+              OPERATOR_TEMPO_VERSION=$(params.OPERATOR_TEMPO_VERSION)
+              OPERATOR_TEMPO_QUERY_VERSION=$(params.OPERATOR_TEMPO_QUERY_VERSION)
+              OPERAND_TEMPO_VERSION=$(params.OPERAND_TEMPO_VERSION)
+
+              function log_cmd() {
+                  echo "\$ $*"
+                  "$@"
+              }
+              function exit_error() {
+                  >&2 echo -e "ERROR: $*"
+                  exit 1
+              }
+
+              function generate_random_name() {
+                  echo "random-name-$RANDOM"
+              }
+
+              function wait_for_pod_running() {
+                  local pod_name=$1
+                  local namespace=$2
+                  while true; do
+                      pod_status=$(oc get pod $pod_name -n $namespace -o jsonpath='{.status.phase}')
+                      if [ "$pod_status" == "Running" ]; then
+                          break
+                      elif [ "$pod_status" == "Failed" ] || [ "$pod_status" == "Unknown" ]; then
+                          exit_error "Pod $pod_name failed to start. Status: $pod_status"
+                      fi
+                      sleep 2
+                  done
+              }
+
+              function check_strings_in_logs() {
+                  local pod_name=$1
+                  local namespace=$2
+                  shift 2
+                  local strings=("$@")
+
+                  logs=$(oc logs pod/$pod_name -n $namespace)
+                  for string in "${strings[@]}"; do
+                      if ! echo "$logs" | grep -q "$string"; then
+                          exit_error "String '$string' not found in logs of pod $pod_name"
+                      fi
+                  done
+              }
+
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+
+              echo
+              echo
+              echo "TEMPO IMAGE DETAILS AND VERSION INFO"
+              echo
+
+              export TEMPO_ICSP=https://raw.githubusercontent.com/os-observability/konflux-tempo/refs/heads/main/.tekton/integration-tests/resources/ImageContentSourcePolicy.yaml
+              curl -H "Authorization: token $KONFLUX_TEMPO_TOKEN" -Lo /tmp/ImageContentSourcePolicy.yaml "$TEMPO_ICSP"
+
+              tempo_images=$(oc get deployment tempo-operator-controller -n openshift-tempo-operator -o yaml | grep -o "registry.redhat.io/rhosdt/.*" | sort | uniq)
+              [ $(echo "$tempo_images" | wc -l) -eq 6 ] || exit_error "Expected 6 images, found:\n$tempo_images"
+
+              oc project default
+
+              for image in $tempo_images; do
+                  oc image info "$image" --icsp-file /tmp/ImageContentSourcePolicy.yaml --filter-by-os linux/amd64
+                  echo
+
+                  random_name=$(generate_random_name)
+
+                  if [[ $image == *tempo-rhel9@* ]]; then
+                      log_cmd oc run $random_name --image=$image -- --version
+                      wait_for_pod_running $random_name default
+                      log_cmd oc logs pod/$random_name
+                      check_strings_in_logs $random_name default "$OPERAND_TEMPO_VERSION"
+                  elif [[ $image == *tempo-gateway-rhel9* || $image == *tempo-gateway-opa-rhel9* || $image == *tempo-query-rhel9* ]]; then
+                      echo "SKIPPED: $image doesn't have a version command"
+                  elif [[ $image == *tempo-rhel9-operator@* ]]; then
+                      log_cmd oc run $random_name --image=$image -- version
+                      wait_for_pod_running $random_name default
+                      log_cmd oc logs pod/$random_name
+                      check_strings_in_logs $random_name default "$OPERATOR_VERSION" "$OPERATOR_TEMPO_VERSION" "$OPERATOR_TEMPO_QUERY_VERSION"
+                  elif [[ $image == *tempo-jaeger-query-rhel9@* ]]; then
+                      log_cmd oc run $random_name --image=$image -- version
+                      wait_for_pod_running $random_name default
+                      log_cmd oc logs pod/$random_name
+                      check_strings_in_logs $random_name default "$JAEGER_QUERY_VERSION"
+                  else
+                      log_cmd oc run $random_name --image=$image -- version
+                      wait_for_pod_running $random_name default
+                      log_cmd oc logs pod/$random_name
+                  fi
+
+                  echo
+                  echo
+              done
+    - name: dast-test
+      description: Task to run Dynamic Application Security Testing (DAST) using RapiDAST
+      runAfter:
+        - operators-install
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      taskSpec:
+        volumes:
+          - name: credentials
+            emptyDir: {}
+          - name: gcs-key
+            secret:
+              secretName: rapidast-sa-rhosdt-key
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: rapidast-scan
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+              - name: gcs-key
+                mountPath: /etc/gcs
+                readOnly: true
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: RHOSDT_VERSION
+                value: $(params.rhosdt_version)
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
+            script: |
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+
+              echo "Clone distributed-tracing-qe repository"
+              git clone https://github.com/openshift/distributed-tracing-qe.git /tmp/distributed-tracing-tests
+              cd /tmp/distributed-tracing-tests
+
+              # Generate GCS secret manifest for chainsaw to apply on the ephemeral cluster
+              kubectl create secret generic rapidast-sa-rhosdt-key \
+                --from-file=sa-key=/etc/gcs/sa-key \
+                --namespace=rapidast-tempo \
+                --dry-run=client -o yaml > tests/e2e-rh-sdl/rapidast-tempo/gcs-secret.yaml
+
+              # Unset environment variable which conflicts with Chainsaw
+              unset NAMESPACE
+
+              # Execute DAST test using RapiDAST
+              chainsaw test \
+              --config .chainsaw-rh-sdl.yaml \
+              --test-dir \
+              tests/e2e-rh-sdl/rapidast-tempo
+    - name: tempo-e2e-tests
+      description: Task to run tests from service repository
+      runAfter:
+        - dast-test
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      params:
+        - name: TEMPO_TESTS_BRANCH
+          value: $(params.tempo_tests_branch)
+        - name: SKIP_TESTS
+          value: $(params.skip_tests)
+      taskSpec:
+        params:
+          - name: TEMPO_TESTS_BRANCH
+            type: string
+          - name: SKIP_TESTS
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: run-e2e-tests
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
+            script: |
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+              TEMPO_TESTS_BRANCH=$(params.TEMPO_TESTS_BRANCH)
+              SKIP_TESTS=$(params.SKIP_TESTS)
+
+              echo "Run e2e tests"
+              git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests
+              cd /tmp/tempo-tests
+              git checkout $TEMPO_TESTS_BRANCH
+
+              #Enable user workload monitoring.
+              oc apply -f tests/e2e-openshift/monitoring/01-workload-monitoring.yaml
+            
+              # Remove test cases to be skipped from the test run
+              IFS=' ' read -ra SKIP_TEST_ARRAY <<< "$SKIP_TESTS"
+              SKIP_TESTS_TO_REMOVE=""
+              INVALID_TESTS=""
+              for test in "${SKIP_TEST_ARRAY[@]}"; do
+                if [[ "$test" == tests/* ]]; then
+                  SKIP_TESTS_TO_REMOVE+=" $test"
+                else
+                  INVALID_TESTS+=" $test"
+                fi
+              done
+
+              if [[ -n "$INVALID_TESTS" ]]; then
+                echo "These test cases are not valid to be skipped: $INVALID_TESTS"
+              fi
+
+              if [[ -n "$SKIP_TESTS_TO_REMOVE" ]]; then
+                rm -rf $SKIP_TESTS_TO_REMOVE
+              fi
+
+              # Unset environment variable which conflicts with Chainsaw
+              unset NAMESPACE
+
+              # Execute Tempo e2e tests
+              chainsaw test \
+              --quiet \
+              --config .chainsaw-openshift.yaml \
+              --test-dir \
+              tests/e2e \
+              tests/e2e-openshift \
+              tests/e2e-openshift-serverless \
+              tests/e2e-openshift-ossm \
+              tests/operator-metrics \
+              tests/e2e-long-running \
+              tests/e2e-openshift-object-stores

--- a/.tekton/single-arch-build-pipeline.yaml
+++ b/.tekton/single-arch-build-pipeline.yaml
@@ -76,6 +76,10 @@ spec:
     default: docker
     type: string
     description: The format for the resulting image's mediaType. Valid values are oci or docker.
+  - name: is-bundle
+    default: "false"
+    type: string
+    description: Set to "true" when the pipeline builds an operator bundle image. Enables OLMv1 compliance validation.
   results:
   - description: ""
     name: IMAGE_URL
@@ -478,6 +482,119 @@ spec:
       operator: in
       values:
       - "false"
+  - name: validate-olmv1-compliance
+    description: |
+      Static validation that the built operator bundle is installable under OLMv1.
+      Fails if the CSV lacks AllNamespaces support, or if metadata/dependencies.yaml
+      requires OLMv0 runtime dependencies (olm.package / olm.gvk / olm.constraint).
+      Runtime-only concerns (OPERATOR_CONDITIONS_NAME, OperatorCondition usage)
+      are reported as advisory warnings only.
+      Validation rules and citations: see scripts/validate-olmv1-compliance.py.
+      Authoritative OLMv1 docs:
+        https://docs.okd.io/latest/extensions/ce/olmv1-supported-extensions.html
+        https://operator-framework.github.io/operator-controller/project/olmv1_limitations/
+    runAfter:
+    - build-image-index
+    when:
+    - input: $(params.is-bundle)
+      operator: in
+      values:
+      - "true"
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    taskSpec:
+      params:
+      - name: IMAGE_URL
+        type: string
+      - name: IMAGE_DIGEST
+        type: string
+      - name: SOURCE_ARTIFACT
+        type: string
+        description: Trusted artifact URI for the cloned source (provides scripts/).
+      volumes:
+      - name: workdir
+        emptyDir: {}
+      steps:
+      - name: use-trusted-artifact
+        image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+        args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        volumeMounts:
+        - name: workdir
+          mountPath: /var/workdir
+      - name: validate
+        image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+        env:
+        - name: BUNDLE_IMAGE
+          value: $(params.IMAGE_URL)@$(params.IMAGE_DIGEST)
+        volumeMounts:
+        - name: workdir
+          mountPath: /var/workdir
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exec bash /var/workdir/source/scripts/validate-olmv1-compliance.sh
+  - name: validate-bundle-sdk
+    description: |
+      Generic operator bundle static validation via `operator-sdk bundle validate`.
+      Catches RBAC, CRD, annotation, and image-reference issues that the
+      OLMv1-specific checks in validate-olmv1-compliance do not cover.
+      Selectors: operatorhub, good-practices.
+      Reference:
+        https://sdk.operatorframework.io/docs/cli/operator-sdk_bundle_validate/
+    runAfter:
+    - build-image-index
+    when:
+    - input: $(params.is-bundle)
+      operator: in
+      values:
+      - "true"
+    params:
+    - name: IMAGE_URL
+      value: $(tasks.build-image-index.results.IMAGE_URL)
+    - name: IMAGE_DIGEST
+      value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: SOURCE_ARTIFACT
+      value: $(tasks.prefetch-dependencies.results.SOURCE_ARTIFACT)
+    taskSpec:
+      params:
+      - name: IMAGE_URL
+        type: string
+      - name: IMAGE_DIGEST
+        type: string
+      - name: SOURCE_ARTIFACT
+        type: string
+        description: Trusted artifact URI for the cloned source (provides scripts/).
+      volumes:
+      - name: workdir
+        emptyDir: {}
+      steps:
+      - name: use-trusted-artifact
+        image: quay.io/konflux-ci/build-trusted-artifacts:latest@sha256:9bd32f6bafb517b309e11a2d89365052b4ab3f1c9c23c4ffd45aff6f03960476
+        args:
+        - use
+        - $(params.SOURCE_ARTIFACT)=/var/workdir/source
+        volumeMounts:
+        - name: workdir
+          mountPath: /var/workdir
+      - name: validate
+        image: registry.access.redhat.com/ubi9/ubi-minimal:latest
+        env:
+        - name: BUNDLE_IMAGE
+          value: $(params.IMAGE_URL)@$(params.IMAGE_DIGEST)
+        volumeMounts:
+        - name: workdir
+          mountPath: /var/workdir
+        script: |
+          #!/usr/bin/env bash
+          set -euo pipefail
+          exec bash /var/workdir/source/scripts/validate-bundle-sdk.sh
   - name: apply-tags
     params:
     - name: IMAGE_URL

--- a/.tekton/tempo-bundle-pull-request.yaml
+++ b/.tekton/tempo-bundle-pull-request.yaml
@@ -41,6 +41,8 @@ spec:
     value: .
   - name: build-source-image
     value: "true"
+  - name: is-bundle
+    value: "true"
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/.tekton/tempo-bundle-push.yaml
+++ b/.tekton/tempo-bundle-push.yaml
@@ -42,6 +42,8 @@ spec:
   - name: build-args
     value:
       - REGISTRY=registry.redhat.io
+  - name: is-bundle
+    value: "true"
   pipelineRef:
     name: single-arch-build-pipeline
   taskRunTemplate:

--- a/scripts/validate-bundle-sdk.sh
+++ b/scripts/validate-bundle-sdk.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+#
+# Generic operator bundle validation via `operator-sdk bundle validate`.
+#
+# Catches generic bundle issues (RBAC shape, CRD validity, annotations,
+# image references, etc.) that the OLMv1-specific checks in
+# validate-olmv1-compliance.py do not cover. Runs the default validator
+# plus selected optional validators.
+#
+# Reference:
+#   https://sdk.operatorframework.io/docs/cli/operator-sdk_bundle_validate/
+#
+# Selectors enabled (start conservative; add more as the bundle stabilizes):
+#   - name=operatorhub      — OperatorHub publishing rules (Red Hat
+#                             products effectively follow this)
+#   - name=good-practices   — generic operator best practices
+#
+# Why this exists: there is no Konflux catalog task that wraps
+# `operator-sdk bundle validate` against a pre-built bundle image today.
+# When one is published upstream, replace the pipeline step with a
+# `taskRef` and remove this script.
+#
+# Inputs: BUNDLE_IMAGE env var — pullable bundle reference.
+# Outputs: exits 0 if all selected validators pass, non-zero otherwise.
+
+set -euo pipefail
+
+if [ -z "${BUNDLE_IMAGE:-}" ]; then
+  echo "BUNDLE_IMAGE env var is required (e.g. registry/ns/bundle@sha256:...)" >&2
+  exit 1
+fi
+
+OPERATOR_SDK_VERSION="${OPERATOR_SDK_VERSION:-v1.41.0}"
+
+echo "Installing tools"
+microdnf install -y --nodocs skopeo file tar gzip findutils >/dev/null
+
+ARCH=$(uname -m)
+case "${ARCH}" in
+  x86_64)  SDK_ARCH=amd64 ;;
+  aarch64) SDK_ARCH=arm64 ;;
+  *) echo "unsupported arch: ${ARCH}" >&2; exit 1 ;;
+esac
+
+echo "Installing operator-sdk ${OPERATOR_SDK_VERSION} (${SDK_ARCH})"
+curl -fsSL -o /usr/local/bin/operator-sdk \
+  "https://github.com/operator-framework/operator-sdk/releases/download/${OPERATOR_SDK_VERSION}/operator-sdk_linux_${SDK_ARCH}"
+chmod +x /usr/local/bin/operator-sdk
+
+echo "Pulling and extracting bundle: ${BUNDLE_IMAGE}"
+WORKDIR=$(mktemp -d)
+OCI_DIR="${WORKDIR}/oci"
+EXTRACT_DIR="${WORKDIR}/extract"
+mkdir -p "${OCI_DIR}" "${EXTRACT_DIR}"
+
+skopeo copy --retry-times 3 \
+  "docker://${BUNDLE_IMAGE}" \
+  "oci:${OCI_DIR}:latest"
+
+# Bundle images are scratch + manifests/ + metadata/, so the extracted
+# layers form a valid bundle root that operator-sdk can validate directly.
+for blob in "${OCI_DIR}"/blobs/sha256/*; do
+  if file -b "${blob}" 2>/dev/null | grep -q gzip; then
+    tar -xzf "${blob}" -C "${EXTRACT_DIR}" 2>/dev/null || true
+  fi
+done
+
+echo "Running operator-sdk bundle validate against ${EXTRACT_DIR}"
+exec operator-sdk bundle validate "${EXTRACT_DIR}" \
+  --select-optional=name=operatorhub \
+  --select-optional=name=good-practices

--- a/scripts/validate-bundle-sdk.sh
+++ b/scripts/validate-bundle-sdk.sh
@@ -48,13 +48,27 @@ curl -fsSL -o /usr/local/bin/operator-sdk \
 chmod +x /usr/local/bin/operator-sdk
 
 echo "Pulling and extracting bundle: ${BUNDLE_IMAGE}"
+
+# Konflux passes IMAGE_URL@IMAGE_DIGEST and IMAGE_URL already carries a tag,
+# yielding "repo:tag@sha256:..." which skopeo rejects ("Docker references
+# with both a tag and digest are currently not supported"). Strip the tag.
+PULL_REF="${BUNDLE_IMAGE}"
+if [[ "${PULL_REF}" == *@* ]]; then
+  _name="${PULL_REF%@*}"
+  _digest="${PULL_REF##*@}"
+  _last="${_name##*/}"
+  if [[ "${_last}" == *:* ]]; then
+    PULL_REF="${_name%/*}/${_last%%:*}@${_digest}"
+  fi
+fi
+
 WORKDIR=$(mktemp -d)
 OCI_DIR="${WORKDIR}/oci"
 EXTRACT_DIR="${WORKDIR}/extract"
 mkdir -p "${OCI_DIR}" "${EXTRACT_DIR}"
 
 skopeo copy --retry-times 3 \
-  "docker://${BUNDLE_IMAGE}" \
+  "docker://${PULL_REF}" \
   "oci:${OCI_DIR}:latest"
 
 # Bundle images are scratch + manifests/ + metadata/, so the extracted

--- a/scripts/validate-olmv1-compliance.py
+++ b/scripts/validate-olmv1-compliance.py
@@ -69,6 +69,24 @@ published (e.g., in konflux-ci/build-definitions), the pipeline step in
 .tekton/single-arch-build-pipeline.yaml should be replaced with a
 `taskRef` to that canonical task and these scripts removed.
 
+Why `operator-sdk bundle validate` is not sufficient
+----------------------------------------------------
+Verified against operator-framework/api validator source
+(pkg/validation/internal/, sdk v1.41.0):
+
+  - AllNamespaces requirement: csv.go enforces AllNamespaces-only ONLY
+    when the CSV has conversionCRDs in webhookDefinitions. A CSV with
+    just OwnNamespace/SingleNamespace passes `operator-sdk bundle
+    validate` but fails under OLMv1.
+  - olm.package / olm.gvk / olm.constraint in metadata/dependencies.yaml:
+    no validator inspects this file. good_practices.go actively
+    *recommends* OLM dependency resolution, the opposite of what OLMv1
+    needs.
+  - OPERATOR_CONDITIONS_NAME env var: not referenced by any validator.
+  - The string "OLMv1" does not appear in any validator — all selectors
+    (operatorhub, good-practices, community, alpha-deprecated-apis,
+    multiarch) predate OLMv1 and only encode OLMv0-era assumptions.
+
 Inputs
 ------
 Reads EXTRACT_DIR from env — the path where the bundle image's gzip

--- a/scripts/validate-olmv1-compliance.py
+++ b/scripts/validate-olmv1-compliance.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+"""Static OLMv1 compliance validation for an extracted operator bundle.
+
+Background — what is OLMv1?
+---------------------------
+OLMv1 (Operator Lifecycle Manager v1) is the next-generation operator
+install/management framework on OpenShift, GA on OCP 4.21+. It replaces
+OLMv0's Subscription / InstallPlan / CSV-driven install flow with a
+ClusterExtension-based model. Bundles still ship in the same OCI format
+(manifests/ + metadata/) but must additionally satisfy OLMv1's stricter
+install constraints in order to install successfully under OLMv1.
+
+Authoritative references for everything below:
+
+  [1] OKD — Supported extensions (OLMv1):
+      https://docs.okd.io/latest/extensions/ce/olmv1-supported-extensions.html
+  [2] Red Hat OpenShift 4.21 — Extensions (mirrored content of [1]):
+      https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html-single/extensions/index
+  [3] operator-controller upstream — OLMv1 limitations:
+      https://operator-framework.github.io/operator-controller/project/olmv1_limitations/
+
+What this script validates (and why)
+------------------------------------
+Hard failures (block the pipeline):
+
+  1. AllNamespaces install mode is supported in the CSV.
+     Why: OLMv1 only honors AllNamespaces today; per [3], a bundle
+     "must support installation via the AllNamespaces install mode".
+     SingleNamespace / OwnNamespace are accepted by OLMv1 for OLMv0
+     backwards compatibility but "are not recommended" [3], and per [1]
+     watching a specific namespace is Tech Preview only. A CSV without
+     AllNamespaces=true is therefore unsafe to ship under OLMv1.
+     Refs: [1], [3].
+
+  2. metadata/dependencies.yaml does not declare olm.package, olm.gvk,
+     or olm.constraint runtime dependencies.
+     Why: OLMv1 does not implement OLM-style dependency resolution. Per
+     [3], a bundle "must not declare dependencies using any of the
+     following file-based catalog properties: olm.gvk.required,
+     olm.package.required, olm.constraint". The same constraint applies
+     to the equivalent runtime-dependency entries in
+     metadata/dependencies.yaml — OLMv1 will not satisfy them either.
+     Refs: [1], [3].
+
+Advisory warning (does not fail the pipeline):
+
+  - Deployment containers should not read OPERATOR_CONDITIONS_NAME.
+    Why: OLMv1 does not implement the OperatorConditions API. Per [1]
+    and [3], "OLM v1 does not support the OperatorConditions API".
+    OLMv1 therefore does not inject OPERATOR_CONDITIONS_NAME into the
+    operator's pod env. Operators that branch on this var will silently
+    degrade. Warning only — not all operators that read this var
+    actually require it to be set.
+    Refs: [1], [3].
+
+What this script intentionally does NOT check
+---------------------------------------------
+ConversionWebhook in the CSV: per [1], "OLM v1 supports Operators that
+use webhooks for validation, mutation, or conversion." Conversion
+webhooks are explicitly supported on OCP 4.21+, so we do not block on
+them. (Earlier OLMv1 tech-preview releases did not support conversion
+webhooks; that restriction was lifted at GA.)
+
+Why this script exists (and not a Konflux task)
+-----------------------------------------------
+There is no Konflux catalog task for OLMv1 static bundle validation
+today. This in-tree script fills the gap. If/when an upstream task is
+published (e.g., in konflux-ci/build-definitions), the pipeline step in
+.tekton/single-arch-build-pipeline.yaml should be replaced with a
+`taskRef` to that canonical task and these scripts removed.
+
+Inputs
+------
+Reads EXTRACT_DIR from env — the path where the bundle image's gzip
+layers have already been extracted (done by the .sh wrapper). Expects
+to find manifests/*.clusterserviceversion.yaml and, optionally,
+metadata/dependencies.yaml under that root.
+
+Exit code: 0 if compliant (warnings allowed), non-zero otherwise.
+"""
+import glob
+import os
+import sys
+import yaml
+
+extract_dir = os.environ["EXTRACT_DIR"]
+
+csv_matches = glob.glob(
+    f"{extract_dir}/**/manifests/*.clusterserviceversion.yaml",
+    recursive=True,
+)
+if not csv_matches:
+    print("FAIL: no ClusterServiceVersion found under manifests/ in bundle image")
+    sys.exit(1)
+csv_path = csv_matches[0]
+print(f"Found CSV: {csv_path}")
+
+with open(csv_path) as f:
+    csv = yaml.safe_load(f)
+
+errors = []
+warnings = []
+
+# Check 1: AllNamespaces install mode must be supported by the CSV.
+# OLMv1 currently only honors AllNamespaces; SingleNamespace / OwnNamespace
+# exist for OLMv0 backwards compatibility but are not recommended, and
+# watching a specific namespace under OLMv1 is Tech Preview only.
+# Refs:
+#   https://docs.okd.io/latest/extensions/ce/olmv1-supported-extensions.html
+#   https://operator-framework.github.io/operator-controller/project/olmv1_limitations/
+install_modes = (csv.get("spec") or {}).get("installModes") or []
+all_ns = next((m for m in install_modes if m.get("type") == "AllNamespaces"), None)
+if not all_ns or not all_ns.get("supported", False):
+    errors.append(
+        "CSV does not support AllNamespaces install mode "
+        "(required by OLMv1 — see "
+        "https://operator-framework.github.io/operator-controller/project/olmv1_limitations/)."
+    )
+
+# Check 2: No OLMv0-only runtime dependencies in metadata/dependencies.yaml.
+# OLMv1 does not implement OLM-style dependency resolution, so
+# olm.package / olm.gvk / olm.constraint entries are never satisfied.
+# Refs:
+#   https://operator-framework.github.io/operator-controller/project/olmv1_limitations/
+#   https://docs.okd.io/latest/extensions/ce/olmv1-supported-extensions.html
+deps_files = glob.glob(
+    f"{extract_dir}/**/metadata/dependencies.yaml",
+    recursive=True,
+)
+blocked_dep_types = {"olm.package", "olm.gvk", "olm.constraint"}
+for dep_path in deps_files:
+    with open(dep_path) as f:
+        deps = yaml.safe_load(f) or {}
+    for dep in deps.get("dependencies") or []:
+        t = dep.get("type", "")
+        if t in blocked_dep_types:
+            errors.append(
+                f"metadata/dependencies.yaml declares OLMv0 runtime dependency "
+                f"type='{t}' (not supported by OLMv1 — see "
+                f"https://operator-framework.github.io/operator-controller/project/olmv1_limitations/)."
+            )
+
+# Advisory check: OPERATOR_CONDITIONS_NAME in deployment env.
+# OLMv1 does not implement the OperatorConditions API and does not inject
+# OPERATOR_CONDITIONS_NAME into the operator's pod env. Operators that
+# branch on this var may silently degrade. Warning only — many operators
+# read it defensively but do not actually require it.
+# Refs:
+#   https://docs.okd.io/latest/extensions/ce/olmv1-supported-extensions.html
+#   https://operator-framework.github.io/operator-controller/project/olmv1_limitations/
+deployments = (
+    ((csv.get("spec") or {}).get("install") or {})
+    .get("spec", {})
+    .get("deployments", [])
+    or []
+)
+for d in deployments:
+    containers = (
+        (d.get("spec") or {})
+        .get("template", {})
+        .get("spec", {})
+        .get("containers", [])
+        or []
+    )
+    for c in containers:
+        for env in c.get("env") or []:
+            if env.get("name") == "OPERATOR_CONDITIONS_NAME":
+                warnings.append(
+                    f"deployment '{d.get('name')}' container '{c.get('name')}' "
+                    f"reads OPERATOR_CONDITIONS_NAME; OLMv1 does not set this env var."
+                )
+
+if warnings:
+    print("OLMv1 advisory warnings:")
+    for w in warnings:
+        print(f"  WARN: {w}")
+
+if errors:
+    print("OLMv1 compliance check FAILED:")
+    for e in errors:
+        print(f"  FAIL: {e}")
+    sys.exit(1)
+
+print("OLMv1 compliance check PASSED")

--- a/scripts/validate-olmv1-compliance.sh
+++ b/scripts/validate-olmv1-compliance.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+#
+# OLMv1 compliance validation — bundle extraction wrapper.
+#
+# Pulls the built operator bundle image, extracts its layers, and hands off
+# to validate-olmv1-compliance.py to perform the actual checks. See that
+# script's module docstring for the full list of OLMv1 rules being validated,
+# the rationale for each, and links to the authoritative OLMv1 docs.
+#
+# Quick reference index (full citations live in the .py docstring):
+#   - OKD supported extensions:
+#     https://docs.okd.io/latest/extensions/ce/olmv1-supported-extensions.html
+#   - Red Hat OCP 4.21 extensions:
+#     https://docs.redhat.com/en/documentation/openshift_container_platform/4.21/html-single/extensions/index
+#   - operator-controller upstream limitations:
+#     https://operator-framework.github.io/operator-controller/project/olmv1_limitations/
+#
+# Why this exists: there is no Konflux catalog task for OLMv1 static bundle
+# validation yet. Once one is published upstream (konflux-ci/build-definitions),
+# the pipeline step should switch to a `taskRef` and these scripts can go away.
+#
+# Inputs: BUNDLE_IMAGE env var — pullable bundle reference (registry/ns/name@sha256:...).
+# Outputs: exits 0 if the bundle is OLMv1-compliant, non-zero otherwise.
+
+set -euo pipefail
+
+if [ -z "${BUNDLE_IMAGE:-}" ]; then
+  echo "BUNDLE_IMAGE env var is required (e.g. registry/ns/bundle@sha256:...)" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+echo "Installing tools"
+microdnf install -y --nodocs skopeo python3 python3-pyyaml file tar gzip findutils >/dev/null
+
+echo "Validating OLMv1 compliance for: ${BUNDLE_IMAGE}"
+
+WORKDIR=$(mktemp -d)
+OCI_DIR="${WORKDIR}/oci"
+EXTRACT_DIR="${WORKDIR}/extract"
+mkdir -p "${OCI_DIR}" "${EXTRACT_DIR}"
+
+skopeo copy --retry-times 3 \
+  "docker://${BUNDLE_IMAGE}" \
+  "oci:${OCI_DIR}:latest"
+
+# Bundle images are scratch + manifests/ + metadata/, so blind-extracting every
+# gzip layer is cheap and robust against layer ordering / digest changes.
+for blob in "${OCI_DIR}"/blobs/sha256/*; do
+  if file -b "${blob}" 2>/dev/null | grep -q gzip; then
+    tar -xzf "${blob}" -C "${EXTRACT_DIR}" 2>/dev/null || true
+  fi
+done
+
+export EXTRACT_DIR
+exec python3 "${SCRIPT_DIR}/validate-olmv1-compliance.py"

--- a/scripts/validate-olmv1-compliance.sh
+++ b/scripts/validate-olmv1-compliance.sh
@@ -36,13 +36,26 @@ microdnf install -y --nodocs skopeo python3 python3-pyyaml file tar gzip finduti
 
 echo "Validating OLMv1 compliance for: ${BUNDLE_IMAGE}"
 
+# Konflux passes IMAGE_URL@IMAGE_DIGEST and IMAGE_URL already carries a tag,
+# yielding "repo:tag@sha256:..." which skopeo rejects ("Docker references
+# with both a tag and digest are currently not supported"). Strip the tag.
+PULL_REF="${BUNDLE_IMAGE}"
+if [[ "${PULL_REF}" == *@* ]]; then
+  _name="${PULL_REF%@*}"
+  _digest="${PULL_REF##*@}"
+  _last="${_name##*/}"
+  if [[ "${_last}" == *:* ]]; then
+    PULL_REF="${_name%/*}/${_last%%:*}@${_digest}"
+  fi
+fi
+
 WORKDIR=$(mktemp -d)
 OCI_DIR="${WORKDIR}/oci"
 EXTRACT_DIR="${WORKDIR}/extract"
 mkdir -p "${OCI_DIR}" "${EXTRACT_DIR}"
 
 skopeo copy --retry-times 3 \
-  "docker://${BUNDLE_IMAGE}" \
+  "docker://${PULL_REF}" \
   "oci:${OCI_DIR}:latest"
 
 # Bundle images are scratch + manifests/ + metadata/, so blind-extracting every


### PR DESCRIPTION
Three pieces of OLMv1-readiness infrastructure for the Tempo operator bundle, gated on bundle / FBC builds:

1. validate-olmv1-compliance task in the bundle build pipeline. Static checks against the built bundle image:

   - spec.installModes must include {type: AllNamespaces, supported: true}
   - metadata/dependencies.yaml must not declare olm.package / olm.gvk / olm.constraint runtime dependencies

   Plus an advisory warning if any deployment container reads
   OPERATOR_CONDITIONS_NAME (OLMv1 does not set this env var).

   Validation logic lives in scripts/validate-olmv1-compliance.{sh,py},
   consumed via SOURCE_ARTIFACT trusted artifact rather than inline in
   the pipeline. The .py docstring carries the full rule list with
   citations to the OLMv1 docs.

2. validate-bundle-sdk task in the bundle build pipeline. Wraps `operator-sdk bundle validate` (selectors: operatorhub, good-practices) to catch RBAC, CRD, annotation, and image-reference issues the OLMv1-specific checks do not cover. operator-sdk version pinned via OPERATOR_SDK_VERSION (default v1.41.0).

3. OLMv1 e2e pipeline at .tekton/integration-tests/pipelines/ tempo-operator-e2e-test-pipeline-4-21-olmv1.yaml. Copy of the 4-18 ROSA e2e pipeline with three changes:

   - cluster version prefix bumped to 4.21.
   - tempo-install rewritten: resolves the FBC component from the snapshot, applies a ClusterCatalog backed by that FBC image, creates an installer ServiceAccount + cluster-admin binding (TODO marker for minimal RBAC), applies a ClusterExtension for the tempo-product package on the stable channel, and waits for Installed=True plus the operator deployment to become Available.
   - description updated.

   Designed to run on FBC application snapshots (e.g. tempo-fbc-v4-21-
   main) so the FBC under test is in the snapshot. Wiring up an
   IntegrationTestScenario to point at this file is a follow-up.

Both static-check tasks are in-tree because no Konflux catalog task wraps these checks against pre-built bundle images yet -- replace with taskRefs once published upstream.

The tempo bundle passes the static checks today (TRACING-5719 confirmed successful OLMv1 install + runtime on OCP 4.21); these tasks guard against future regressions.

Refs:
- https://docs.okd.io/latest/extensions/ce/olmv1-supported-extensions.html
- https://operator-framework.github.io/operator-controller/project/olmv1_limitations/
- https://sdk.operatorframework.io/docs/cli/operator-sdk_bundle_validate/
- OCPSTRAT-2268, TRACING-5751