### PR TITLE
fix: update api submodule with go-jose/v4 v4.1.4 security patch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -8,7 +8,8 @@
 	branch = rhosdt-3.9
 [submodule "api"]
 	path = api
-	url = https://github.com/observatorium/api.git
+	url = https://github.com/os-observability/api.git
+	branch = rhosdt-3.9
 [submodule "opa-openshift"]
 	path = opa-openshift
 	url = https://github.com/observatorium/opa-openshift.git


### PR DESCRIPTION
## Summary
- Points the `api` submodule to `os-observability/api` fork on the `rhosdt-3.9` branch
- Includes the `go-jose/go-jose/v4` bump from v4.1.3 to v4.1.4 (upstream [observatorium/api#896](https://github.com/observatorium/api/pull/896))

## Test plan
- [ ] Verify the api submodule resolves correctly
- [ ] Confirm the api builds with the updated dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)