### PR TITLE
Add tempo-operator.v0.21.0-1 channel entry to catalog template

### DIFF
--- a/catalog/catalog-template.yaml
+++ b/catalog/catalog-template.yaml
@@ -77,6 +77,9 @@ entries:
   - name: tempo-operator.v0.20.0-3
     replaces: tempo-operator.v0.20.0-2
     skipRange: '>=0.6.0 <0.20.0-3'
+  - name: tempo-operator.v0.21.0-1
+    replaces: tempo-operator.v0.20.0-3
+    skipRange: '>=0.6.0 <0.21.0-1'
   name: stable
   package: tempo-product
   schema: olm.channel
@@ -128,6 +131,8 @@ entries:
   schema: olm.bundle
 - image: registry.redhat.io/rhosdt/tempo-operator-bundle@sha256:44aab3cb00053aff888ce8bbadca241807c6d400e881db4208dbcd1c311335ad
   schema: olm.bundle
-- image: quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-bundle@sha256:39fe9cd7bd5d0c5fc8af54c12cfe5aa901ac67b55f305384bbd9492d9e487b5f
+- image: registry.redhat.io/rhosdt/tempo-operator-bundle@sha256:39fe9cd7bd5d0c5fc8af54c12cfe5aa901ac67b55f305384bbd9492d9e487b5f
+  schema: olm.bundle
+- image: quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-bundle@sha256:67b8b644749cdc301c7ed10be7c8ac23f3bd32f7069b5eeb4c380db111b4fa59
   schema: olm.bundle
 schema: olm.template.basic


### PR DESCRIPTION
## Problem

The **Generate FBC catalogs** check fails (on `main` and on every renovate bundle bump, e.g. #784) with:

```
level=fatal msg="package \"tempo-product\", bundle \"tempo-operator.v0.21.0-1\" not found in any channel entries"
```

**Root cause:** #776 bumped the operator build to `0.21.0-1` (Dockerfiles, `bundle-patch/patch_csv.yaml`, `versions.sh`) but did **not** update `catalog/catalog-template.yaml`. The stable channel still tops out at `v0.20.0-3`, while every new bundle build — including `main`'s own `catalog.env` bundle `67b8b64` — now renders as `v0.21.0-1`. The rendered `v0.21.0-1` bundle is therefore orphaned (no channel entry references it) and `opm validate` rejects it.

## Fix

- Add the `tempo-operator.v0.21.0-1` channel entry (`replaces: tempo-operator.v0.20.0-3`, `skipRange: '>=0.6.0 <0.21.0-1'`).
- Promote the previous in-flight bundle `39fe9cd` (v0.20.0-3) from `quay.io` → `registry.redhat.io`, so it stays resolvable once the quay in-flight slot advances to `v0.21.0-1`. This mirrors how #730 crossed versions.

`opm validate` passes on the resulting template.

## Note

CI's render step needs `registry.redhat.io/rhosdt/tempo-operator-bundle@sha256:39fe9cd...` (v0.20.0-3) to be published — it becomes available with the 0.21.0-1 release. Until then the render step will report `manifest unknown` for that digest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)