### PR TITLE
fix(pipelines): update tempo-operator git clone URL to os-observability org

### DIFF
--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-14.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-14.yaml
@@ -626,7 +626,7 @@ spec:
               SKIP_TESTS=$(params.SKIP_TESTS)
 
               echo "Run e2e tests"
-              git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests
+              git clone https://github.com/os-observability/tempo-operator.git /tmp/tempo-tests
               cd /tmp/tempo-tests
               git checkout $TEMPO_TESTS_BRANCH
 
@@ -665,6 +665,7 @@ spec:
               tests/e2e-openshift \
               tests/e2e-openshift-serverless \
               tests/e2e-openshift-ossm \
-              tests/operator-metrics \
+              tests/e2e-openshift-object-stores \
               tests/e2e-long-running \
-              tests/e2e-openshift-object-stores
+              tests/e2e-openshift-tshirt-sizes \
+              tests/operator-metrics

--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-18.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-18.yaml
@@ -626,7 +626,7 @@ spec:
               SKIP_TESTS=$(params.SKIP_TESTS)
 
               echo "Run e2e tests"
-              git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests
+              git clone https://github.com/os-observability/tempo-operator.git /tmp/tempo-tests
               cd /tmp/tempo-tests
               git checkout $TEMPO_TESTS_BRANCH
 
@@ -665,6 +665,7 @@ spec:
               tests/e2e-openshift \
               tests/e2e-openshift-serverless \
               tests/e2e-openshift-ossm \
-              tests/operator-metrics \
+              tests/e2e-openshift-object-stores \
               tests/e2e-long-running \
-              tests/e2e-openshift-object-stores
+              tests/e2e-openshift-tshirt-sizes \
+              tests/operator-metrics

--- a/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-21-olmv1.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-e2e-test-pipeline-4-21-olmv1.yaml
@@ -729,7 +729,7 @@ spec:
               SKIP_TESTS=$(params.SKIP_TESTS)
 
               echo "Run e2e tests"
-              git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests
+              git clone https://github.com/os-observability/tempo-operator.git /tmp/tempo-tests
               cd /tmp/tempo-tests
               git checkout $TEMPO_TESTS_BRANCH
 
@@ -768,6 +768,7 @@ spec:
               tests/e2e-openshift \
               tests/e2e-openshift-serverless \
               tests/e2e-openshift-ossm \
-              tests/operator-metrics \
+              tests/e2e-openshift-object-stores \
               tests/e2e-long-running \
-              tests/e2e-openshift-object-stores
+              tests/e2e-openshift-tshirt-sizes \
+              tests/operator-metrics

--- a/.tekton/integration-tests/pipelines/tempo-operator-upgrade-test-fbc-pipeline-4-14.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-upgrade-test-fbc-pipeline-4-14.yaml
@@ -237,7 +237,7 @@ spec:
               TEMPO_TESTS_BRANCH=$(params.TEMPO_TESTS_BRANCH)
 
               echo "Run upgrade tests"
-              git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests
+              git clone https://github.com/os-observability/tempo-operator.git /tmp/tempo-tests
               cd /tmp/tempo-tests
               git checkout $TEMPO_TESTS_BRANCH
 

--- a/.tekton/integration-tests/pipelines/tempo-operator-upgrade-test-fbc-pipeline-4-18.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-upgrade-test-fbc-pipeline-4-18.yaml
@@ -237,7 +237,7 @@ spec:
               TEMPO_TESTS_BRANCH=$(params.TEMPO_TESTS_BRANCH)
 
               echo "Run upgrade tests"
-              git clone https://github.com/IshwarKanse/tempo-operator.git /tmp/tempo-tests
+              git clone https://github.com/os-observability/tempo-operator.git /tmp/tempo-tests
               cd /tmp/tempo-tests
               git checkout $TEMPO_TESTS_BRANCH
 


### PR DESCRIPTION
## Summary

- Update all e2e test pipelines (4-14, 4-18, 4-21-olmv1) to clone from `os-observability/tempo-operator` instead of the personal fork
- Update upgrade test pipelines (4-14, 4-18) with the same repo URL fix
- Reorder test suites in e2e pipelines and add `tests/e2e-openshift-tshirt-sizes`

## Test plan
- [x] Verify CI pipelines clone from the correct `os-observability/tempo-operator` repo
- [x] Verify e2e tests run with the updated test suite order

🤖 Generated with [Claude Code](https://claude.com/claude-code)