### PR TITLE
fix(dockerfiles): update embedded Tempo VERSION to 2.10.5

### DIFF
--- a/Dockerfile.tempo
+++ b/Dockerfile.tempo
@@ -16,7 +16,7 @@ WORKDIR /opt/app-root/src/tempo
 RUN exportOrFail() { echo $1; if [[ $1 == *= ]]; then echo "Error: empty variable assignment"; exit 1; else export "$1"; fi } && \
     exportOrFail GIT_BRANCH=`git rev-parse --abbrev-ref HEAD` && \
     exportOrFail GIT_REVISION=`git rev-parse --short HEAD` && \
-    exportOrFail VERSION="2.10.3" && \
+    exportOrFail VERSION="2.10.5" && \
     CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -C ./cmd/tempo -tags strictfipsruntime -mod vendor \
       -o "tempo" -trimpath -ldflags "-s -w -X main.Branch=${GIT_BRANCH} -X main.Revision=${GIT_REVISION} -X main.Version=${VERSION}"
 

--- a/Dockerfile.tempoquery
+++ b/Dockerfile.tempoquery
@@ -16,7 +16,7 @@ WORKDIR /opt/app-root/src/tempo
 RUN exportOrFail() { echo $1; if [[ $1 == *= ]]; then echo "Error: empty variable assignment"; exit 1; else export "$1"; fi } && \
     exportOrFail GIT_BRANCH=`git rev-parse --abbrev-ref HEAD` && \
     exportOrFail GIT_REVISION=`git rev-parse --short HEAD` && \
-    exportOrFail VERSION="2.10.3" && \
+    exportOrFail VERSION="2.10.5" && \
     CGO_ENABLED=1 GOEXPERIMENT=strictfipsruntime go build -C ./cmd/tempo-query -tags strictfipsruntime -mod vendor \
       -o "tempo-query" -trimpath -ldflags "-s -w -X main.Branch=${GIT_BRANCH} -X main.Revision=${GIT_REVISION} -X main.Version=${VERSION}"
 


### PR DESCRIPTION
## What

Update the embedded `VERSION` in `Dockerfile.tempo` and `Dockerfile.tempoquery` from `2.10.3` to `2.10.5`.

## Why

The `tempo` submodule points to `v2.10.5` (`git describe` → `v2.10.5-1-g038fd16e8`), but both Dockerfiles still hard-coded `exportOrFail VERSION="2.10.3"` — the value last set in #708 when Tempo was at 2.10.3.

`versions.sh` is what propagates the submodule tag into these `VERSION` lines, but it was never re-run after the submodule was bumped to 2.10.5 (#769). The subsequent Dockerfile change (#776) only touched the bundle `ARG VERSION`, not the binary `VERSION`. As a result the released `tempo`/`tempo-query` binaries reported the stale `2.10.3` via the `-X main.Version=${VERSION}` ldflag.

## Note

Applied as a targeted edit rather than a full `versions.sh` run, since that script also recomputes the bundle build number against a live cluster (`kubectl get packagemanifests`), which isn't available locally. These two lines are the only Tempo-version change the script would have made.

🤖 Generated with [Claude Code](https://claude.com/claude-code)