### PR TITLE
Bump versions for 3.10.1 (-3)

### DIFF
--- a/Dockerfile.bundle
+++ b/Dockerfile.bundle
@@ -25,7 +25,7 @@ RUN ./update_bundle.sh && cat manifests/tempo-operator.clusterserviceversion.yam
 FROM scratch
 WORKDIR /
 
-ARG VERSION=0.21.0-2
+ARG VERSION=0.21.0-3
 
 COPY tempo-operator/LICENSE /licenses/.
 

--- a/Dockerfile.gateway
+++ b/Dockerfile.gateway
@@ -30,7 +30,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.21.0-2
+ARG VERSION=0.21.0-3
 
 RUN mkdir /licenses
 COPY api/LICENSE /licenses/.

--- a/Dockerfile.jaegerquery
+++ b/Dockerfile.jaegerquery
@@ -60,7 +60,7 @@ RUN rm -rf /mnt/rootfs/var/cache/*
 
 FROM scratch
 
-ARG VERSION=0.21.0-2
+ARG VERSION=0.21.0-3
 
 WORKDIR /opt/app-root/src/
 COPY --from=install-additional-packages /mnt/rootfs/ /

--- a/Dockerfile.opa
+++ b/Dockerfile.opa
@@ -30,7 +30,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.21.0-2
+ARG VERSION=0.21.0-3
 
 RUN mkdir /licenses
 COPY opa-openshift/LICENSE /licenses/.

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -48,7 +48,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.21.0-2
+ARG VERSION=0.21.0-3
 
 RUN mkdir /licenses
 COPY tempo-operator/LICENSE /licenses/.

--- a/Dockerfile.tempo
+++ b/Dockerfile.tempo
@@ -35,7 +35,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.21.0-2
+ARG VERSION=0.21.0-3
 
 RUN mkdir /licenses
 COPY tempo/LICENSE /licenses/.

--- a/Dockerfile.tempoquery
+++ b/Dockerfile.tempoquery
@@ -35,7 +35,7 @@ FROM scratch
 WORKDIR /
 COPY --from=install-additional-packages /mnt/rootfs/ /
 
-ARG VERSION=0.21.0-2
+ARG VERSION=0.21.0-3
 
 RUN mkdir /licenses
 COPY tempo/LICENSE /licenses/.

--- a/bundle-patch/patch_csv.yaml
+++ b/bundle-patch/patch_csv.yaml
@@ -16,11 +16,11 @@ metadata:
     features.operators.openshift.io/cni: "false"
     features.operators.openshift.io/csi: "false"
     console.openshift.io/operator-monitoring-default: "true"
-    olm.skipRange: '>=0.6.0 <0.21.0-2'
-  name: tempo-operator.v0.21.0-2
+    olm.skipRange: '>=0.6.0 <0.21.0-3'
+  name: tempo-operator.v0.21.0-3
 spec:
-  version: 0.21.0-2
-  replaces: tempo-operator.v0.21.0-1
+  version: 0.21.0-3
+  replaces: tempo-operator.v0.21.0-2
   description: |-
     Red Hat OpenShift distributed tracing platform based on Tempo. Tempo is an open-source, easy-to-use, and highly scalable distributed tracing backend. It provides observability for microservices architectures by allowing developers to track requests as they flow through distributed systems. Tempo is optimized to handle large volumes of trace data and is designed to be highly performant even under heavy loads.
     It can ingest common open source tracing protocols including Jaeger, Zipkin, and OpenTelemetry and requires only object storage to operate.


### PR DESCRIPTION
Rebuild bump `0.21.0-2` -> `0.21.0-3`, mirroring #826 (commit 40f1cc3).

## Changes
- `Dockerfile.{bundle,gateway,jaegerquery,opa,operator,tempo,tempoquery}`: `ARG VERSION=0.21.0-3`
- `bundle-patch/patch_csv.yaml`:
  - `olm.skipRange` -> `'>=0.6.0 <0.21.0-3'`
  - `name` -> `tempo-operator.v0.21.0-3`
  - `version` -> `0.21.0-3`
  - `replaces` -> `tempo-operator.v0.21.0-2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)