### PR TITLE
Add Konflux pipeline for distributed tracing console plugin UI tests

### DIFF
--- a/.tekton/integration-tests/pipelines/tempo-operator-tracing-ui-tests-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-tracing-ui-tests-pipeline-4-21.yaml
@@ -1,0 +1,430 @@
+---
+apiVersion: tekton.dev/v1beta1
+kind: Pipeline
+metadata:
+  annotations:
+    pipelinesascode.tekton.dev/task: "[tempo-install, coo-operators-install, tracing-ui-tests]"
+  name: tempo-operator-tracing-ui-tests-pipeline
+spec:
+  description: |
+    This pipeline runs the Distributed Tracing Console Plugin Cypress integration tests
+    against the Tempo Operator on an ephemeral OpenShift cluster. It provisions the cluster,
+    installs Tempo Operator from the Konflux bundle, installs COO and dependent operators
+    from redhat-operators, and runs the Cypress UI tests from the
+    openshift/distributed-tracing-console-plugin repository.
+  params:
+    - name: SNAPSHOT
+      description: 'The JSON string representing the snapshot of the application under test.'
+      default: '{"components": [{"name":"test-app", "containerImage": "quay.io/example/repo:latest"}]}'
+      type: string
+    - name: test-name
+      description: 'The name of the test corresponding to a defined Konflux integration test.'
+      default: 'tempo-operator-tracing-ui-tests'
+    - name: namespace
+      description: 'Namespace to install Tempo Operator'
+      default: 'openshift-tempo-operator'
+    - name: skip_tests
+      description: "Cypress grep pattern to skip tests. Example: '-Lightspeed' or '~Lightspeed|~Debug'"
+      default: ''
+    - name: lightspeed_provider_url
+      description: "Lightspeed provider URL for AI-powered trace analysis integration"
+      default: ''
+    - name: lightspeed_provider_token
+      description: "Lightspeed API authentication token for AI-powered trace analysis integration"
+      default: ''
+  tasks:
+    - name: parse-metadata
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/integration-examples
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: tasks/test_metadata.yaml
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+    - name: eaas-provision-space
+      runAfter:
+        - parse-metadata
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      taskRef:
+        resolver: git
+        params:
+          - name: url
+            value: https://github.com/konflux-ci/build-definitions.git
+          - name: revision
+            value: main
+          - name: pathInRepo
+            value: task/eaas-provision-space/0.1/eaas-provision-space.yaml
+      params:
+        - name: ownerKind
+          value: PipelineRun
+        - name: ownerName
+          value: $(context.pipelineRun.name)
+        - name: ownerUid
+          value: $(context.pipelineRun.uid)
+    - name: provision-cluster
+      runAfter:
+        - eaas-provision-space
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      taskSpec:
+        results:
+          - name: clusterName
+            value: "$(steps.create-cluster.results.clusterName)"
+        steps:
+          - name: get-supported-versions
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-supported-ephemeral-cluster-versions/0.1/eaas-get-supported-ephemeral-cluster-versions.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+          - name: pick-version
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-latest-openshift-version-by-prefix/0.1/eaas-get-latest-openshift-version-by-prefix.yaml
+            params:
+              - name: prefix
+                value: "4.21."
+          - name: create-cluster
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-create-ephemeral-cluster-hypershift-aws/0.1/eaas-create-ephemeral-cluster-hypershift-aws.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: version
+                value: "$(steps.pick-version.results.version)"
+              - name: instanceType
+                value: "m5.2xlarge"
+              - name: timeout
+                value: "40m"
+              - name: fips
+                value: "false"
+              - name: imageContentSources
+                value: |
+                  - source: registry.redhat.io/rhosdt/tempo-rhel9-operator
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-operator
+                  - source: registry.redhat.io/rhosdt/tempo-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo
+                  - source: registry.redhat.io/rhosdt/tempo-query-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-query
+                  - source: registry.redhat.io/rhosdt/tempo-jaeger-query-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-jaeger-query
+                  - source: registry.redhat.io/rhosdt/tempo-gateway-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-gateway
+                  - source: registry.redhat.io/rhosdt/tempo-gateway-opa-rhel9
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-opa
+                  - source: registry.redhat.io/rhosdt/tempo-operator-bundle
+                    mirrors:
+                      - quay.io/redhat-user-workloads/rhosdt-tenant/tempo/tempo-bundle
+    - name: tempo-install
+      description: Task to install Tempo Operator bundle onto ephemeral cluster
+      runAfter:
+        - provision-cluster
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      params:
+        - name: SNAPSHOT
+          value: $(params.SNAPSHOT)
+        - name: namespace
+          value: "$(params.namespace)"
+      taskSpec:
+        params:
+          - name: SNAPSHOT
+          - name: namespace
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: install-operator
+            env:
+              - name: SNAPSHOT
+                value: $(params.SNAPSHOT)
+              - name: KONFLUX_COMPONENT_NAME
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.labels['appstudio.openshift.io/component']
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
+            script: |
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+
+              echo "Create namespace to install Tempo Operator"
+              oc create namespace $(params.namespace)
+              oc label namespaces $(params.namespace) openshift.io/cluster-monitoring=true --overwrite=true
+
+              echo "Get the bundle image"
+              echo ${KONFLUX_COMPONENT_NAME}
+              export BUNDLE_IMAGE="$(jq -r --arg component_name "$KONFLUX_COMPONENT_NAME" '.components[] | select(.name == $component_name) | .containerImage' <<< "$SNAPSHOT")"
+              echo "${BUNDLE_IMAGE}"
+
+              echo "Install Tempo Operator"
+              operator-sdk run bundle --timeout=5m --namespace "$(params.namespace)" "$BUNDLE_IMAGE" --verbose
+              oc wait --for condition=Available -n "$(params.namespace)" deployment tempo-operator-controller
+    - name: coo-operators-install
+      description: Task to install COO, OpenTelemetry and Lightspeed operators
+      runAfter:
+        - tempo-install
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      taskSpec:
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: install-operators
+            env:
+              - name: KONFLUX_TEMPO_TOKEN
+                valueFrom:
+                  secretKeyRef:
+                    name: konflux-tempo-access-token-read-only
+                    key: token
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            image: quay.io/redhat-distributed-tracing-qe/konflux-e2e:latest
+            script: |
+              #!/bin/bash
+              set -eu
+
+              echo "Kubeconfig file"
+              cat $KUBECONFIG
+
+              echo "Installing dependent operators"
+              export OPERATORS_INSTALL=https://raw.githubusercontent.com/os-observability/konflux-tempo/refs/heads/main/.tekton/integration-tests/resources/tracing-ui-install.yaml
+              curl -H "Authorization: token $KONFLUX_TEMPO_TOKEN" -Lo /tmp/tracing-ui-install.yaml "$OPERATORS_INSTALL"
+              oc apply -f /tmp/tracing-ui-install.yaml
+
+              retry_count=30
+              sleep_duration=30
+
+              check_operator_installed() {
+                local operator=$1
+                local namespace=$2
+                local csv=""
+
+                for i in $(seq $retry_count); do
+                  if [[ -z "$csv" ]]; then
+                    csv=$(oc get subscription -n "$namespace" "$operator" -o jsonpath='{.status.installedCSV}' 2>/dev/null || true)
+                  fi
+
+                  if [[ -z "$csv" ]]; then
+                    echo "Try ${i}/${retry_count}: can't get the $operator CSV yet. Checking again in $sleep_duration seconds"
+                    sleep $sleep_duration
+                  else
+                    if [[ $(oc get csv -n "$namespace" "$csv" -o jsonpath='{.status.phase}' 2>/dev/null || true) == "Succeeded" ]]; then
+                      echo "$operator is successfully installed in namespace $namespace"
+                      return 0
+                    else
+                      echo "Try ${i}/${retry_count}: $operator is not deployed yet. Checking again in $sleep_duration seconds"
+                      sleep $sleep_duration
+                    fi
+                  fi
+                done
+
+                echo "$operator installation failed after $retry_count retries in namespace $namespace."
+                return 1
+              }
+
+              echo "Checking installation status of operators..."
+              check_operator_installed "cluster-observability-operator" "openshift-cluster-observability-operator"
+              check_operator_installed "opentelemetry-product" "openshift-opentelemetry-operator"
+              check_operator_installed "lightspeed-operator" "openshift-lightspeed"
+              echo "Operator installation check completed."
+    - name: tracing-ui-tests
+      description: Task to run Distributed Tracing Console Plugin Cypress integration tests
+      runAfter:
+        - coo-operators-install
+      when:
+        - input: $(tasks.parse-metadata.results.test-event-type)
+          operator: in
+          values: [ "push", "Push", "PUSH", "incoming", "Incoming", "INCOMING" ]
+      params:
+        - name: SKIP_TESTS
+          value: $(params.skip_tests)
+        - name: LIGHTSPEED_PROVIDER_URL
+          value: "$(params.lightspeed_provider_url)"
+        - name: LIGHTSPEED_PROVIDER_TOKEN
+          value: "$(params.lightspeed_provider_token)"
+      taskSpec:
+        params:
+          - name: SKIP_TESTS
+            type: string
+          - name: LIGHTSPEED_PROVIDER_URL
+            type: string
+          - name: LIGHTSPEED_PROVIDER_TOKEN
+            type: string
+        volumes:
+          - name: credentials
+            emptyDir: {}
+        steps:
+          - name: get-kubeconfig
+            ref:
+              resolver: git
+              params:
+                - name: url
+                  value: https://github.com/konflux-ci/build-definitions.git
+                - name: revision
+                  value: main
+                - name: pathInRepo
+                  value: stepactions/eaas-get-ephemeral-cluster-credentials/0.1/eaas-get-ephemeral-cluster-credentials.yaml
+            params:
+              - name: eaasSpaceSecretRef
+                value: $(tasks.eaas-provision-space.results.secretRef)
+              - name: clusterName
+                value: "$(tasks.provision-cluster.results.clusterName)"
+              - name: credentials
+                value: credentials
+          - name: run-tracing-ui-tests
+            volumeMounts:
+              - name: credentials
+                mountPath: /credentials
+            env:
+              - name: KUBECONFIG
+                value: "/credentials/$(steps.get-kubeconfig.results.kubeconfig)"
+              - name: CYPRESS_SKIP_COO_INSTALL
+                value: "true"
+              - name: CYPRESS_COO_NAMESPACE
+                value: "openshift-cluster-observability-operator"
+              - name: CYPRESS_LIGHTSPEED_PROVIDER_URL
+                value: "$(params.LIGHTSPEED_PROVIDER_URL)"
+              - name: CYPRESS_LIGHTSPEED_PROVIDER_TOKEN
+                value: "$(params.LIGHTSPEED_PROVIDER_TOKEN)"
+            computeResources:
+              requests:
+                cpu: "1"
+                memory: 3Gi
+              limits:
+                cpu: "8"
+                memory: 8Gi
+            image: quay.io/redhat-distributed-tracing-qe/cypress-base:latest
+            script: |
+              #!/bin/bash
+              set -o nounset
+              set -o pipefail
+
+              SKIP_TESTS="$(params.SKIP_TESTS)"
+
+              if ! (oc get clusteroperator console) ; then
+                echo "Console is not installed, skipping all console tests."
+                exit 0
+              fi
+
+              # Read kubeadmin password from credentials
+              KUBEADMIN_PASSWORD_FILE="/credentials/$(steps.get-kubeconfig.results.passwordPath)"
+              if [[ ! -f "${KUBEADMIN_PASSWORD_FILE}" ]]; then
+                echo "Error: Kubeadmin password file ${KUBEADMIN_PASSWORD_FILE} does not exist"
+                exit 1
+              fi
+              kubeadmin_password=$(cat "${KUBEADMIN_PASSWORD_FILE}")
+              echo "Successfully read kubeadmin password"
+
+              # Set Cypress environment variables
+              export CYPRESS_KUBECONFIG_PATH=$KUBECONFIG
+              console_route=$(oc get route console -n openshift-console -o jsonpath='{.spec.host}')
+              export CYPRESS_BASE_URL=https://$console_route
+
+              export CYPRESS_LOGIN_IDP=kube:admin
+              export CYPRESS_LOGIN_USERS=kubeadmin:${kubeadmin_password}
+
+              export NO_COLOR=1
+              export CYPRESS_CACHE_FOLDER=/tmp/Cypress
+
+              # Clone and run Cypress tests
+              repo_url="https://github.com/openshift/distributed-tracing-console-plugin.git"
+              target_dir="/tmp/distributed-tracing-console-plugin"
+
+              echo "Cloning distributed-tracing-console-plugin repository"
+              git clone "$repo_url" "$target_dir"
+              cd "$target_dir/tests" || exit 1
+
+              npm install || true
+
+              if [[ -n "${SKIP_TESTS}" ]]; then
+                echo "Running Cypress tests with grep pattern: ${SKIP_TESTS}"
+                npx cypress run --browser chrome --headless --env grep="${SKIP_TESTS}",grepOmitFiltered=true || true
+              else
+                echo "Running all Cypress tests"
+                npm run test-cypress-console-headless || true
+              fi
+

--- a/.tekton/integration-tests/resources/tracing-ui-install.yaml
+++ b/.tekton/integration-tests/resources/tracing-ui-install.yaml
@@ -1,0 +1,86 @@
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-cluster-observability-operator
+
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
+spec: {}
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-observability-operator
+  namespace: openshift-cluster-observability-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: cluster-observability-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-opentelemetry-operator
+
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-opentelemetry-operator
+  namespace: openshift-opentelemetry-operator
+spec:
+  upgradeStrategy: Default
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: opentelemetry-product
+  namespace: openshift-opentelemetry-operator
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: opentelemetry-product
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+
+---
+apiVersion: project.openshift.io/v1
+kind: Project
+metadata:
+  name: openshift-lightspeed
+
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-lightspeed
+  namespace: openshift-lightspeed
+spec:
+  targetNamespaces:
+    - openshift-lightspeed
+
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: lightspeed-operator
+  namespace: openshift-lightspeed
+spec:
+  channel: stable
+  installPlanApproval: Automatic
+  name: lightspeed-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace


### PR DESCRIPTION
## Summary
- Add a new Tekton integration pipeline (`tempo-operator-tracing-ui-tests-pipeline-4-21.yaml`) to run Cypress UI tests from `openshift/distributed-tracing-console-plugin` on an EaaS OCP 4.21 ephemeral cluster
- Installs Tempo Operator from the Konflux bundle, COO, OpenTelemetry, and Lightspeed operators via OLM subscriptions
- Runs headless Chrome Cypress tests using kubeadmin authentication, with Lightspeed credentials passed as pipeline params