### PR TITLE
Remove unsupported computeResources from tracing-ui-tests pipeline

### DIFF
--- a/.tekton/integration-tests/pipelines/tempo-operator-tracing-ui-tests-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-tracing-ui-tests-pipeline-4-21.yaml
@@ -362,13 +362,6 @@ spec:
                   secretKeyRef:
                     name: lightspeed-credentials
                     key: lightspeed-provider-token
-            computeResources:
-              requests:
-                cpu: "1"
-                memory: 3Gi
-              limits:
-                cpu: "8"
-                memory: 8Gi
             image: quay.io/redhat-distributed-tracing-qe/cypress-base:latest
             script: |
               #!/bin/bash


### PR DESCRIPTION
## Summary
- Remove `computeResources` field from the `run-tracing-ui-tests` step in the tracing-ui-tests pipeline
- This field is not supported in Tekton v1beta1 used by Konflux, causing strict decoding validation failure: `unknown field "spec.tasks[5].taskSpec.steps[1].computeResources"`