### PR TITLE
Fix step result substitution in tracing-ui-tests script

### DIFF
--- a/.tekton/integration-tests/pipelines/tempo-operator-tracing-ui-tests-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-tracing-ui-tests-pipeline-4-21.yaml
@@ -362,6 +362,8 @@ spec:
                   secretKeyRef:
                     name: lightspeed-credentials
                     key: lightspeed-provider-token
+              - name: KUBEADMIN_PASSWORD_FILE
+                value: "/credentials/$(steps.get-kubeconfig.results.passwordPath)"
             image: quay.io/redhat-distributed-tracing-qe/cypress-base:latest
             script: |
               #!/bin/bash
@@ -376,7 +378,6 @@ spec:
               fi
 
               # Read kubeadmin password from credentials
-              KUBEADMIN_PASSWORD_FILE="/credentials/$(steps.get-kubeconfig.results.passwordPath)"
               if [[ ! -f "${KUBEADMIN_PASSWORD_FILE}" ]]; then
                 echo "Error: Kubeadmin password file ${KUBEADMIN_PASSWORD_FILE} does not exist"
                 exit 1


### PR DESCRIPTION
## Summary
- Move `$(steps.get-kubeconfig.results.passwordPath)` from the `script:` block to a `KUBEADMIN_PASSWORD_FILE` env var
- Tekton v1beta1 only allows step result substitutions (`$(steps.*.results.*)`) in `env`, `command`, and `args` fields — not in `script`
- Fixes: `PipelineValidationFailed: stepResult substitutions are only allowed in env, command and args. Found usage in: spec.tasks[5].taskSpec.steps[1].script`