### PR TITLE
Add resource limits for tracing-ui-tests Cypress step

### DIFF
--- a/.tekton/integration-tests/pipelines/tempo-operator-tracing-ui-tests-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-tracing-ui-tests-pipeline-4-21.yaml
@@ -364,6 +364,13 @@ spec:
                     key: lightspeed-provider-token
               - name: KUBEADMIN_PASSWORD_FILE
                 value: "/credentials/$(steps.get-kubeconfig.results.passwordPath)"
+            resources:
+              requests:
+                cpu: "1"
+                memory: 3Gi
+              limits:
+                cpu: "8"
+                memory: 8Gi
             image: quay.io/redhat-distributed-tracing-qe/cypress-base:latest
             script: |
               #!/bin/bash


### PR DESCRIPTION
## Summary
- Add `resources` (Kubernetes standard field) with memory limits to the `run-tracing-ui-tests` step
- Chrome headless + Cypress needs more memory than the default allocation — step was OOMKilled (exit code 137)
- Uses `resources` (Tekton v1beta1 compatible) instead of `computeResources` (Tekton v1 only, removed in #876)
- Limits: 8Gi memory / 8 CPU (matching the CI step configuration)