### PR TITLE
Propagate Cypress test failures as step failures

### DIFF
--- a/.tekton/integration-tests/pipelines/tempo-operator-tracing-ui-tests-pipeline-4-21.yaml
+++ b/.tekton/integration-tests/pipelines/tempo-operator-tracing-ui-tests-pipeline-4-21.yaml
@@ -415,9 +415,9 @@ spec:
 
               if [[ -n "${SKIP_TESTS}" ]]; then
                 echo "Running Cypress tests with grep pattern: ${SKIP_TESTS}"
-                npx cypress run --browser chrome --headless --env grep="${SKIP_TESTS}",grepOmitFiltered=true || true
+                npx cypress run --browser chrome --headless --env grep="${SKIP_TESTS}",grepOmitFiltered=true
               else
                 echo "Running all Cypress tests"
-                npm run test-cypress-console-headless || true
+                npm run test-cypress-console-headless
               fi
 


### PR DESCRIPTION
## Summary
- Remove `|| true` from Cypress run commands in the tracing-ui-tests pipeline step so that test failures are properly reported as step failures
- In Konflux, the UI test step is the final step in the pipeline, so failures should propagate (unlike CI where `|| true` is needed to avoid blocking subsequent steps)