### PR TITLE
drop dependabot, mintmaker already updates GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: github-actions
-    directory: /
-    schedule:
-      interval: daily


### PR DESCRIPTION
I didn't realize mintmaker already creates PRs for outdated GitHub Actions